### PR TITLE
Added possibility to directly configure the gelf publisher

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -130,8 +130,22 @@ class MonologExtension extends Extension
             break;
 
         case 'gelf':
+            if (isset($handler['publisher']['id'])) {
+                $publisherId = $handler['publisher']['id'];
+            } else {
+                $publisher = new Definition("%monolog.gelf.publisher.class%", array(
+                    $handler['publisher']['hostname'],
+                    $handler['publisher']['port'],
+                    $handler['publisher']['chunk_size'],
+                ));
+
+                $publisherId = 'monolog.gelf.publisher';
+                $publisher->setPublic(false);
+                $container->setDefinition($publisherId, $publisher);
+            }
+
             $definition->setArguments(array(
-                new Reference($handler['publisher']),
+                new Reference($publisherId),
                 $handler['level'],
                 $handler['bubble'],
             ));

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="monolog.logger.class">Symfony\Bridge\Monolog\Logger</parameter>
+        <parameter key="monolog.gelf.publisher.class">Gelf\MessagePublisher</parameter>
         <parameter key="monolog.handler.stream.class">Monolog\Handler\StreamHandler</parameter>
         <parameter key="monolog.handler.group.class">Monolog\Handler\GroupHandler</parameter>
         <parameter key="monolog.handler.buffer.class">Monolog\Handler\BufferHandler</parameter>

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -18,6 +18,7 @@
             <xsd:element name="email-prototype" type="email-prototype" minOccurs="0" maxOccurs="1" />
             <xsd:element name="member" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="channels" type="channels" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="publisher" type="publisher" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="type" type="xsd:string" />
         <xsd:attribute name="priority" type="xsd:integer" />
@@ -32,7 +33,6 @@
         <xsd:attribute name="buffer-size" type="xsd:integer" />
         <xsd:attribute name="max-files" type="xsd:integer" />
         <xsd:attribute name="handler" type="xsd:string" />
-        <xsd:attribute name="publisher" type="xsd:string" />
         <xsd:attribute name="from-email" type="xsd:string" />
         <xsd:attribute name="to-email" type="xsd:string" />
         <xsd:attribute name="subject" type="xsd:string" />
@@ -63,6 +63,13 @@
             <xsd:enumeration value="550" />
         </xsd:restriction>
     </xsd:simpleType>
+
+    <xsd:complexType name="publisher">
+        <xsd:attribute name="id" type="xsd:string" />
+        <xsd:attribute name="hostname" type="xsd:string" />
+        <xsd:attribute name="port" type="xsd:integer" />
+        <xsd:attribute name="chunk_size" type="xsd:integer" />
+    </xsd:complexType>
 
     <xsd:complexType name="email-prototype">
         <xsd:attribute name="id" type="xsd:string" />

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -32,14 +32,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('handlers', $config);
         $this->assertArrayHasKey('foobar', $config['handlers']);
-        $this->assertEquals('stream',   $config['handlers']['foobar']['type']);
+        $this->assertEquals('stream', $config['handlers']['foobar']['type']);
         $this->assertEquals('/foo/bar', $config['handlers']['foobar']['path']);
     }
 
     public function provideProcessStringChannels()
     {
         return array(
-            array('foo',  'foo', true),
+            array('foo', 'foo', true),
             array('!foo', 'foo', false)
         );
     }
@@ -53,8 +53,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             array(
                 'handlers' => array(
                     'foobar' => array(
-                        'type' =>     'stream',
-                        'path' =>     '/foo/bar',
+                        'type' => 'stream',
+                        'path' => '/foo/bar',
                         'channels' => $string
                     )
                 )
@@ -66,6 +66,43 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($isInclusive ? 'inclusive' : 'exclusive', $config['handlers']['foobar']['channels']['type']);
         $this->assertCount(1, $config['handlers']['foobar']['channels']['elements']);
         $this->assertEquals($expectedString, $config['handlers']['foobar']['channels']['elements'][0]);
+    }
+
+    public function provideGelfPublisher()
+    {
+        return array(
+            array(
+                'gelf.publisher'
+            ),
+            array(
+                array(
+                    'id' => 'gelf.publisher'
+                )
+            )
+        );
+    }
+
+    /**
+     * @dataProvider provideGelfPublisher
+     */
+    public function testGelfPublisherService($publisher)
+    {
+        $configs = array(
+            array(
+                'handlers' => array(
+                    'gelf' => array(
+                        'type' => 'gelf',
+                        'publisher' => $publisher,
+                    ),
+                )
+            )
+        );
+
+        $config = $this->process($configs);
+
+        $this->assertArrayHasKey('id', $config['handlers']['gelf']['publisher']);
+        $this->assertArrayNotHasKey('hostname', $config['handlers']['gelf']['publisher']);
+        $this->assertEquals('gelf.publisher', $config['handlers']['gelf']['publisher']['id']);
     }
 
     public function testArrays()

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -197,6 +197,28 @@ abstract class MonologExtensionTest extends TestCase
     /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
+    public function testExceptionWhenUsingGelfWithoutPublisher()
+    {
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $loader->load(array(array('handlers' => array('gelf' => array('type' => 'gelf')))), $container);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testExceptionWhenUsingGelfWithoutPublisherHostname()
+    {
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $loader->load(array(array('handlers' => array('gelf' => array('type' => 'gelf', 'publisher' => array())))), $container);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
     public function testExceptionWhenUsingServiceWithoutId()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
This PR adds the possibility to configure the publisher for the gelf handler directly (as discussed in #6).

The following examples are valid configurations.

``` yaml
monolog:
    handlers:
        gelf:
            type: gelf
            publisher:
                hostname: localhost # required
                port: 12201 # optional
                chunk_size: 1420 # optional
```

You can optionally define a service id so you can use the publisher wherever you want.

``` yaml
monolog:
    handlers:
        gelf:
            type: gelf
            publisher:
                id: my.publisher.id
                hostname: localhost # required
                port: 12201 # optional
                chunk_size: 1420 # optional
```

However, it is still possible to use your own defined publisher service.

``` yaml
monolog:
    handlers:
        gelf:
            type: gelf
            publisher: my.publisher.service_id

# or

monolog:
    handlers:
        gelf:
            type: gelf
            publisher:
                id: my.publisher.service_id

```
