### PR TITLE
fixed path to composer autoload, exit status code

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,10 +1,15 @@
 <?php
 
-if (!@include __DIR__ . '/../vendor/.composer/autoload.php') {
-    die("You must set up the project dependencies, run the following commands:
-wget http://getcomposer.org/composer.phar
-php composer.phar install
-");
+if (!@include __DIR__ . '/../vendor/autoload.php') {
+    echo <<<EOF
+You must set up the project dependencies, run the following commands:
+
+    wget http://getcomposer.org/composer.phar
+    php composer.phar install
+
+EOF;
+
+    exit(1);
 }
 
 spl_autoload_register(function($class) {


### PR DESCRIPTION
Composer is generating the autoload file in a different location than the bootstrap is looking.
