### PR TITLE
Allowed array of emails for "to_email" parameter.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -96,7 +96,7 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')->end()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function($v) { return array('id' => $v); })
+                                    ->then(function($v) { return array($v); })
                                 ->end()
                             ->end()
                             ->scalarNode('subject')->end() // swift_mailer and native_mailer


### PR DESCRIPTION
``` yml
# app/config/config.yml

monolog:
    handlers:        
        swift:
            type:       swift_mailer
            from_email: error@localhost
            to_email:   [email1@mail.com, email2@mail.com]  # or as always to_email:  email1@mail.com
            subject:    An Error Occurred!
            level:      debug
```
