### PR TITLE
Make logopts for syslog handler configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,6 +60,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('bubble')->defaultTrue()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('ident')->defaultFalse()->end() // syslog
+                            ->scalarNode('logopts')->defaultValue(LOG_PID)->end() // syslog
                             ->scalarNode('facility')->defaultValue('user')->end() // syslog
                             ->scalarNode('max_files')->defaultValue(0)->end() // rotating
                             ->scalarNode('action_level')->defaultValue('WARNING')->end() // fingers_crossed

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -219,6 +219,7 @@ class MonologExtension extends Extension
                 $handler['facility'],
                 $handler['level'],
                 $handler['bubble'],
+                $handler['logopts'],
             ));
             break;
 

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -125,6 +125,21 @@ class MonologExtensionTest extends DependencyInjectionTest
         $loader->load(array(array('handlers' => array('debug' => array('type' => 'stream')))), $container);
     }
 
+    public function testSyslogHandlerWithLogopts()
+    {
+        $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'syslog', 'logopts' => LOG_CONS)))));
+
+        $this->assertTrue($container->hasDefinition('monolog.logger'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.main'));
+
+        $logger = $container->getDefinition('monolog.logger');
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+
+        $handler = $container->getDefinition('monolog.handler.main');
+        $this->assertDICDefinitionClass($handler, '%monolog.handler.syslog.class%');
+        $this->assertDICConstructorArguments($handler, array(false, 'user', \Monolog\Logger::DEBUG, true, LOG_CONS));
+    }
+
     protected function getContainer(array $config = array())
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
We noticed that using the configuration we cannot set the logopts parameter for the syslog handler. This pull request rectifies that by adding it as an option to the handler setting.
