### PR TITLE
prevent using monolog 1.3.x-dev before PSR-3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/monolog-bridge": ">=2.1.0,<2.3-dev",
         "symfony/dependency-injection": ">=2.1.0,<2.3-dev",
         "symfony/config": ">=2.1.0,<2.3-dev",
-        "monolog/monolog": "<=1.2.1"
+        "monolog/monolog": ">=1.0,<1.3-dev"
     },
     "require-dev": {
         "symfony/yaml": ">=2.1.0,<2.3-dev",


### PR DESCRIPTION
Before symfony isn't updated to PSR-3, monolog 1.3.x-dev will lead to fatal error.
Force monolog to latest stable.
