### PR TITLE
Explicit Version of monolog dependency for Symfony2.1 Bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/monolog-bridge": ">=2.1.0,<2.3-dev",
         "symfony/dependency-injection": ">=2.1.0,<2.3-dev",
         "symfony/config": ">=2.1.0,<2.3-dev",
-        "monolog/monolog": "1.*"
+        "monolog/monolog": "1.2.1"
     },
     "require-dev": {
         "symfony/yaml": ">=2.1.0,<2.3-dev",


### PR DESCRIPTION
The MonologBundle throws the following error, when including it in a Symfony 2.1 Application.

```
Fatal error: Can't inherit abstract function Symfony\Component\HttpKernel\Log\LoggerInterface::alert() (previously declared abstract in Psr\Log\LoggerInterface)
 in C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Bridge\Monolog\Logger.php on line 23

Call Stack:
    0.0002     336760   1. {main}() C:\projects\iRed\project\app\console:0
    0.0287    2280256   2. Symfony\Component\Console\Application->run() C:\projects\iRed\project\app\console:22
    0.0346    2528360   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Component\Console\Application.php:105
    0.0346    2528360   4. Symfony\Bundle\FrameworkBundle\Console\Application->registerCommands() C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Bundle\FrameworkBundle\Console\Application.php:68
    0.0346    2528360   5. Symfony\Component\HttpKernel\Kernel->boot() C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Bundle\FrameworkBundle\Console\Application.php:83
    0.0480    2770136   6. Symfony\Component\HttpKernel\Kernel->initializeContainer() C:\projects\iRed\project\app\bootstrap.php.cache:571
    0.0481    2770712   7. Symfony\Component\HttpKernel\Kernel->buildContainer() C:\projects\iRed\project\app\bootstrap.php.cache:859
    0.3368    7278408   8. Symfony\Component\DependencyInjection\ContainerBuilder->compile() C:\projects\iRed\project\app\bootstrap.php.cache:950
    0.3799    7307816   9. Symfony\Component\DependencyInjection\Compiler\Compiler->compile() C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Component\DependencyInjection\ContainerBuilder.php:453
    3.3270   18675904  10. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->process() C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Component\DependencyInjection\Compiler\Compiler.php:119
    3.6291   26451248  11. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->processDefinition() C:\projects\iRed\project\vendor\jms\aop-bundle\JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass.php:59
    3.6291   26451280  12. class_exists() C:\projects\iRed\project\vendor\jms\aop-bundle\JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass.php:96
    3.6291   26451560  13. Symfony\Component\ClassLoader\DebugClassLoader->loadClass() C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Component\ClassLoader\DebugClassLoader.php:0
    3.6297   26461656  14. require('C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Bridge\Monolog\Logger.php') C:\projects\iRed\project\vendor\symfony\symfony\src\Symfony\Component\ClassLoader\DebugClassLoader.php:82

Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-update-cmd event terminated with an exception
```

I assume that the inclusion of psr/log is meant for Symfony 2.2. Creating a 2.1 branch of the bundle - even if it is just for including the correct monolog version - is necessary as to not trip developers waiting before switching to 2.2, or cannot yet make that switch. 

Symfony 2.1 works with Monolog 1.2.1
