### PR TITLE
restricted monolog bridge dependency for 2.1 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/monolog-bridge": ">=2.1.0,<2.3-dev",
+        "symfony/monolog-bridge": "2.1.*",
         "symfony/dependency-injection": ">=2.1.0,<2.3-dev",
         "symfony/config": ">=2.1.0,<2.3-dev",
         "monolog/monolog": ">=1.0,<1.3-dev"


### PR DESCRIPTION
I was getting the following error : "PHP Fatal error:  Class Symfony\Bridge\Monolog\Logger contains 5 abstract method
s and must therefore be declared abstract or implement the remaining methods (Ps(...)"  on a symfony 2.2 project because the dependency was 2.1.\* instead of 2.2.*.
