### PR TITLE
Added configuration parameter to swift mailer handler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -105,6 +105,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('subject')->end() // swift_mailer and native_mailer
                             ->scalarNode('content_type')->defaultNull()->end() // swift_mailer
+                            ->scalarNode('mailer')->defaultValue('mailer')->end() // swift_mailer
                             ->arrayNode('email_prototype') // swift_mailer
                                 ->canBeUnset()
                                 ->beforeNormalization()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -251,7 +251,7 @@ class MonologExtension extends Extension
                 $prototype = new Reference($messageId);
             }
             $definition->setArguments(array(
-                new Reference('mailer'),
+                new Reference($handler['mailer']),
                 $prototype,
                 $handler['level'],
                 $handler['bubble'],

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -196,6 +196,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'from_email' => 'foo@bar.com',
                         'to_email' => 'foo@bar.com',
                         'subject' => 'Subject',
+                        'mailer'  => 'mailer',
                         'email_prototype' => array(
                             'id' => 'monolog.prototype',
                             'method' => 'getPrototype'
@@ -211,6 +212,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $config['handlers']['swift']['email_prototype']);
         $this->assertEquals('monolog.prototype', $config['handlers']['swift']['email_prototype']['id']);
         $this->assertEquals('getPrototype', $config['handlers']['swift']['email_prototype']['method']);
+        $this->assertEquals('mailer', $config['handlers']['swift']['mailer']);
     }
 
     public function testWithType()


### PR DESCRIPTION
This commit adds an optional mailer parameter to the SwiftMailerHandler configuration.
