### PR TITLE
fix xsd type

### DIFF
--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -80,7 +80,7 @@
         <xsd:sequence>
             <xsd:element name="channel" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
-        <xsd:attribute name="type" type="xsd:string" />
+        <xsd:attribute name="type" type="channel_type" />
     </xsd:complexType>
 
     <xsd:simpleType name="channel_type">


### PR DESCRIPTION
Also I think the branches actStrat, channel_setters, phpunit_bootstrap_fixes can be removed because they have been merged, can they?
