### PR TITLE
Allow an array of users for pushover config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -69,7 +69,14 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('buffer_size')->defaultValue(0)->end() // fingers_crossed and buffer
                             ->scalarNode('handler')->end() // fingers_crossed and buffer
                             ->scalarNode('token')->end() // pushover
-                            ->scalarNode('user')->end() // pushover
+                            ->variableNode('user') // pushover
+                                ->validate()
+                                    ->ifTrue(function($v) {
+                                        return !is_string($v) && !is_array($v);
+                                    })
+                                    ->thenInvalid('User must be a string or an array.')
+                                ->end()
+                            ->end()
                             ->scalarNode('title')->defaultNull()->end() // pushover
                             ->arrayNode('publisher')
                                 ->canBeUnset()


### PR DESCRIPTION
This is related to https://github.com/Seldaek/monolog/commit/46cedf5e2f0553d32037fe6e275bff8aec0bb5f3. It doesn't break BC as a string is still valid. However, using an array of users will need version 1.6+ of monolog.
