### PR TITLE
Adds the error log handler to the list of supported handlers

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -195,6 +195,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('id')->end()
+                            ->scalarNode('message_type')->defaultValue(0)->end()
                             ->scalarNode('priority')->defaultValue(0)->end()
                             ->scalarNode('level')->defaultValue('DEBUG')->end()
                             ->booleanNode('bubble')->defaultTrue()->end()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -369,6 +369,13 @@ class MonologExtension extends Extension
             ));
             break;
 
+        case 'errorlog':
+             $definition->setArguments(array(
+                (isset($handler['message_type']) ? $handler['message_type'] : 0),
+                $handler['level'],
+                $handler['bubble'],
+            ));
+            break;
         // Handlers using the constructor of AbstractHandler without adding their own arguments
         case 'newrelic':
         case 'test':

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -13,6 +13,7 @@
         <parameter key="monolog.handler.buffer.class">Monolog\Handler\BufferHandler</parameter>
         <parameter key="monolog.handler.rotating_file.class">Monolog\Handler\RotatingFileHandler</parameter>
         <parameter key="monolog.handler.syslog.class">Monolog\Handler\SyslogHandler</parameter>
+        <parameter key="monolog.handler.errorlog.class">Monolog\Handler\ErrorLogHandler</parameter>
         <parameter key="monolog.handler.null.class">Monolog\Handler\NullHandler</parameter>
         <parameter key="monolog.handler.test.class">Monolog\Handler\TestHandler</parameter>
         <parameter key="monolog.handler.gelf.class">Monolog\Handler\GelfHandler</parameter>


### PR DESCRIPTION
Currently there is no support for using the error log handler that `Monolog` provides, using the same configuration that allows syslog, firephp etc. to be set up.

This patch allows a configuration to be set up as follows (YML in this example):

``` yml
monolog:
    handlers:
        errlog:
            type:  errorlog
            level: error
            message_type: 0
```

`message_type` is either zero or four and defaults to zero
