### PR TITLE
Resolving parameter name before calling class_exists

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -249,7 +249,8 @@ class MonologExtension extends Extension
         case 'swift_mailer':
             $oldHandler = false;
             // fallback for older symfony versions that don't have the new SwiftMailerHandler in the bridge
-            if (!class_exists($definition->getClass())) {
+            $newHandlerClass = $container->getParameterBag()->resolveValue($definition->getClass());
+            if (!class_exists($newHandlerClass)) {
                 $definition = new Definition('Monolog\Handler\SwiftMailerHandler');
                 $oldHandler = true;
             }


### PR DESCRIPTION
The new SwiftMailerHandler introduced in #51 is never used, since class_exists gets parameter name from definition, not the actual class name.

Fixed that by resolving parameter and then calling class_exists with resolved value. 
