### PR TITLE
fix config to work with exactly one value for excluded_404s in XML forma...

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -196,6 +196,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->fixXmlConfig('member')
+                        ->fixXmlConfig('excluded_404')
                         ->canBeUnset()
                         ->children()
                             ->scalarNode('type')


### PR DESCRIPTION
...t

If you specify only one entry of `excluded_404s` in an XML based config, Symfony terminates with a `Invalid type for path "monolog.handlers.main.excluded_404s". Expected array, but got string` error.
