### PR TITLE
fix check to not raise E_NOTICEs

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -87,7 +87,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('formatter')->end()
                         ->end()
                         ->validate()
-                            ->ifTrue(function($v) { return ('fingers_crossed' === $v['type'] || 'buffer' === $v['type']) && 1 !== count($v['handler']); })
+                            ->ifTrue(function($v) { return ('fingers_crossed' === $v['type'] || 'buffer' === $v['type']) && empty($v['handler']); })
                             ->thenInvalid('The handler has to be specified to use a FingersCrossedHandler or BufferHandler')
                         ->end()
                         ->validate()


### PR DESCRIPTION
Imagine this _invalid_ configuration:

``` yml
monolog:
    handlers:
        buffered:
            type: buffer
```

With the current implementation you get an `E_NOTICE`: `Notice: Undefined index: handler`
