### PR TITLE
Respect mailer configuration option.

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -300,12 +300,19 @@ class MonologExtension extends Extension
                 }
             } else {
                 $message = new Definition('Swift_Message');
-                $message->setFactoryService('mailer');
                 $message->setFactoryMethod('createMessage');
                 $message->setPublic(false);
                 $message->addMethodCall('setFrom', array($handler['from_email']));
                 $message->addMethodCall('setTo', array($handler['to_email']));
                 $message->addMethodCall('setSubject', array($handler['subject']));
+
+                if(isset($handler['mailer'])){ 
+                    $mailer = $handler['mailer'];
+                } else {
+                    $mailer = 'mailer';
+                }
+                $message->setFactoryService($mailer);
+
 
                 if (isset($handler['content_type'])) {
                     $message->addMethodCall('setContentType', array($handler['content_type']));


### PR DESCRIPTION
If hander type is swift_mailer mailer was being set to the default 'mailer'. Check if mailer is set in hander and override the default.
