### PR TITLE
Added newer PHP Versions and HHVM to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install --dev
+    - composer self-update
+    - composer install --prefer-source
+
+script: phpunit --coverage-text


### PR DESCRIPTION
Added PHP 5.5, 5.6 and HHVM to Travis configuration.
Using the composer provided by travis.
Letting Coverage be displayed as text.
