### PR TITLE
[SwiftMailer] send error log mails from CLI

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -316,7 +316,7 @@ class MonologExtension extends Extension
                 $message->addMethodCall('setTo', array($handler['to_email']));
                 $message->addMethodCall('setSubject', array($handler['subject']));
 
-                if(isset($handler['mailer'])){ 
+                if(isset($handler['mailer'])){
                     $mailer = $handler['mailer'];
                 } else {
                     $mailer = 'mailer';
@@ -341,6 +341,9 @@ class MonologExtension extends Extension
             if (!$oldHandler) {
                 $this->swiftMailerHandlers[] = $handlerId;
                 $definition->addTag('kernel.event_listener', array('event' => 'kernel.terminate', 'method' => 'onKernelTerminate'));
+                if (method_exists($newHandlerClass, 'onCliTerminate')) {
+                    $definition->addTag('kernel.event_listener', array('event' => 'console.terminate', 'method' => 'onCliTerminate'));
+                }
             }
             break;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Given I have symfony2 application with Monolog configured to send mail on error logs.
When I have exception thrown from CLI task
Then I should receive error mail

However this is not true because `Monolog/SwiftMailerHandler` is doing force flush only on `kernel.terminate`, but not on `console.terminate`

This PR fixes issue together with https://github.com/symfony/symfony/pull/10534
