### PR TITLE
Ability to define the service id for Raven client

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -133,7 +133,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *
  * - raven:
  *   - dsn: connection string
- *   - service_id: Raven client custom service id (optional)
+ *   - client_id: Raven client custom service id (optional)
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *
@@ -345,7 +345,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('connection_timeout')->end() // socket_handler
                             ->booleanNode('persistent')->end() // socket_handler
                             ->scalarNode('dsn')->end() // raven_handler
-                            ->scalarNode('service_id')->defaultNull()->end() // raven_handler
+                            ->scalarNode('client_id')->defaultNull()->end() // raven_handler
                             ->scalarNode('message_type')->defaultValue(0)->end() // error_log
                             ->arrayNode('tags') // loggly
                                 ->beforeNormalization()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -439,8 +439,8 @@ class MonologExtension extends Extension
 
         case 'raven':
             $clientId = 'monolog.raven.client.' . sha1($handler['dsn']);
-            if (null !== $handler['service_id']) {
-                $clientId = $handler['service_id'];
+            if (null !== $handler['client_id']) {
+                $clientId = $handler['client_id'];
             }
             if (!$container->hasDefinition($clientId)) {
                 $client = new Definition("Raven_Client", array(

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -44,6 +44,8 @@
         <xsd:attribute name="notify" type="xsd:boolean" />
         <xsd:attribute name="room" type="xsd:string" />
         <xsd:attribute name="nickname" type="xsd:string" />
+        <xsd:attribute name="dsn" type="xsd:string" />
+        <xsd:attribute name="client_id" type="xsd:string" />
         <xsd:attribute name="use-ssl" type="xsd:boolean" />
     </xsd:complexType>
 

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -195,7 +195,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionClass($handler, '%monolog.handler.raven.class%');
 
         $container = $this->getContainer(array(array('handlers' => array('raven' => array(
-            'type' => 'raven', 'dsn' => $dsn, 'service_id' => 'raven.client')
+            'type' => 'raven', 'dsn' => $dsn, 'client_id' => 'raven.client')
         ))));
 
         $this->assertTrue($container->hasDefinition('raven.client'));


### PR DESCRIPTION
Instead of generating a service id with a big ugly sha1 inside (like `monolog.raven.client.4b9d0f59c45d393c0fc2ac65d6f07ff1b71954cd`) to define the Raven client service, we can define a custom service id.

To register some error handler on the Raven client, we need to manually define the service.
And I found more easily/readable to define the service with a custom name instead of using and ugly sha1 one.
