### PR TITLE
make it possible to use multiple to_email in XML

### DIFF
--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -25,6 +25,7 @@
             <xsd:element name="excluded-404" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="tag" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="accepted-level" type="level" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="to-email" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="type" type="xsd:string" />
         <xsd:attribute name="priority" type="xsd:integer" />

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -136,6 +136,28 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         );
     }
 
+    public function testSingleEmailRecipient()
+    {
+        $container = $this->getContainer('single_email_recipient');
+
+        $this->assertSame(array(
+            array('setFrom', array('error@example.com')),
+            array('setTo', array(array('error@example.com'))),
+            array('setSubject', array('An Error Occurred!')),
+        ), $container->getDefinition('monolog.handler.swift.mail_prototype')->getMethodCalls());
+    }
+
+    public function testMultipleEmailRecipients()
+    {
+        $container = $this->getContainer('multiple_email_recipients');
+
+        $this->assertSame(array(
+            array('setFrom', array('error@example.com')),
+            array('setTo', array(array('dev1@example.com', 'dev2@example.com'))),
+            array('setSubject', array('An Error Occurred!')),
+        ), $container->getDefinition('monolog.handler.swift.mail_prototype')->getMethodCalls());
+    }
+
     protected function getContainer($fixture)
     {
         $container = new ContainerBuilder();

--- a/Tests/DependencyInjection/Fixtures/xml/multiple_email_recipients.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/multiple_email_recipients.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:monolog="http://symfony.com/schema/dic/monolog"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <monolog:config>
+        <monolog:handler
+            name="swift"
+            type="swift_mailer"
+            from-email="error@example.com"
+            subject="An Error Occurred!"
+            level="debug">
+
+            <monolog:to-email>dev1@example.com</monolog:to-email>
+            <monolog:to-email>dev2@example.com</monolog:to-email>
+        </monolog:handler>
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/xml/single_email_recipient.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/single_email_recipient.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:monolog="http://symfony.com/schema/dic/monolog"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <monolog:config>
+        <monolog:handler
+            name="swift"
+            type="swift_mailer"
+            from-email="error@example.com"
+            to-email="error@example.com"
+            subject="An Error Occurred!"
+            level="debug" />
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/yml/multiple_email_recipients.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/multiple_email_recipients.yml
@@ -1,0 +1,8 @@
+monolog:
+    handlers:
+        swift:
+            type:       swift_mailer
+            from_email: error@example.com
+            to_email:   [dev1@example.com, dev2@example.com]
+            subject:    An Error Occurred!
+            level:      debug

--- a/Tests/DependencyInjection/Fixtures/yml/single_email_recipient.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/single_email_recipient.yml
@@ -1,0 +1,8 @@
+monolog:
+    handlers:
+        swift:
+            type:       swift_mailer
+            from_email: error@example.com
+            to_email:   error@example.com
+            subject:    An Error Occurred!
+            level:      debug


### PR DESCRIPTION
The Configuration class allows to configure more than one recipient (see symfony/symfony-docs#4135). Since the `to_email` field was configured as an attribute in XML configurations, it couldn't be specified multiple times.
