### PR TITLE
Do not require raven.dsn when a client_id is specified

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -570,7 +570,7 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The token and user have to be specified to use a PushoverHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'raven' === $v['type'] && !array_key_exists('dsn', $v); })
+                            ->ifTrue(function ($v) { return 'raven' === $v['type'] && !array_key_exists('dsn', $v) && null === $v['client_id']; })
                             ->thenInvalid('The DSN has to be specified to use a RavenHandler')
                         ->end()
                         ->validate()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -468,15 +468,14 @@ class MonologExtension extends Extension
             break;
 
         case 'raven':
-            $clientId = 'monolog.raven.client.' . sha1($handler['dsn']);
             if (null !== $handler['client_id']) {
                 $clientId = $handler['client_id'];
-            }
-            if (!$container->hasDefinition($clientId)) {
+            } else {
                 $client = new Definition("Raven_Client", array(
                     $handler['dsn']
                 ));
                 $client->setPublic(false);
+                $clientId = 'monolog.raven.client.'.sha1($handler['dsn']);
                 $container->setDefinition($clientId, $client);
             }
             $definition->setArguments(array(


### PR DESCRIPTION
Right now, I have the following configuration. And as you can see, the raven.dsn
is useless here, are the client_id service is not buildt by the extension
but by myself.

``` yml
monolog:
    handlers:
        raven:
            type: raven
            # useless, because we set-up a custom client, but we have to...
            dsn:  "%raven.dsn%"
            client_id: sensiolabs.toolkit.monolog.raven_client
```

So with with patch, we can use:

``` yml
monolog:
    handlers:
        raven:
            type: raven
            client_id: sensiolabs.toolkit.monolog.raven_client
```

BTW, I don't know the target branch of this PR.
