### PR TITLE
[MonologBundle] Added token to XSD

### DIFF
--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -56,6 +56,7 @@
         <xsd:attribute name="client-id" type="xsd:string" />
         <xsd:attribute name="use-ssl" type="xsd:boolean" />
         <xsd:attribute name="formatter" type="xsd:string" />
+        <xsd:attribute name="token" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">


### PR DESCRIPTION
When using the LogEntriesHandler combined with XML configuration, the config file will not validate since the 'token' attribute is missing from the XSD

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
