### PR TITLE
Add support for WhatFailureGroupHandler (Monolog ~1.11)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -378,7 +378,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->prototype('scalar')->end()
                             ->end() // rollbar
-                            ->arrayNode('members') // group
+                            ->arrayNode('members') // group, whatfailuregroup
                                 ->canBeUnset()
                                 ->performNoDeepMerging()
                                 ->prototype('scalar')->end()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -308,6 +308,7 @@ class MonologExtension extends Extension
             break;
 
         case 'group':
+        case 'whatfailuregroup':
             $references = array();
             foreach ($handler['members'] as $nestedHandler) {
                 $nestedHandlerId = $this->getHandlerId($nestedHandler);

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -37,6 +37,7 @@
         <parameter key="monolog.handler.error_log.class">Monolog\Handler\ErrorLogHandler</parameter>
         <parameter key="monolog.handler.loggly.class">Monolog\Handler\LogglyHandler</parameter>
         <parameter key="monolog.handler.logentries.class">Monolog\Handler\LogEntriesHandler</parameter>
+        <parameter key="monolog.handler.whatfailuregroup.class">Monolog\Handler\WhatFailureGroupHandler</parameter>
         <parameter key="monolog.activation_strategy.not_found.class">Symfony\Bundle\MonologBundle\NotFoundActivationStrategy</parameter>
 
         <parameter key="monolog.handler.fingers_crossed.class">Monolog\Handler\FingersCrossedHandler</parameter>


### PR DESCRIPTION
Please tag a new version after merging this :-).

Here is an example configuration that can be used to send messages into a Logstash socket.
That socket might not exist or be not writeable in case Logstash crashes/does not run,
but you don't want that to affect your application.

``` yaml
monolog:
  handlers:

    ignore_failures:
      type: whatfailuregroup
      members: [ main ]

    main:
      type:  socket
      connection_string: unix:///path/to/logstash/socket
      level: debug
      connection_timeout: 0.05
```
