### PR TITLE
Set SwiftMailer creation message as lazy.

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -358,6 +358,7 @@ class MonologExtension extends Extension
                 }
             } else {
                 $message = new Definition('Swift_Message');
+                $message->setLazy(true);
                 $message->setFactoryMethod('createMessage');
                 $message->setPublic(false);
                 $message->addMethodCall('setFrom', array($handler['from_email']));


### PR DESCRIPTION
At this moment, with a config:

```
swift:
            type:       swift_mailer
            from_email: user@domain.tld
            to_email:   user@domain.tld
            level:      debug
```

A `Swift_Message` instance is created on each places where `logger` is injected. Everybody know the cost of a  `Swift_Message` instance ... 
