### PR TITLE
Add check to kernel.debug in DebugCompilerPass

### DIFF
--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Monolog\Logger;
 
 /**
- * Adds the DebugHandler when the profiler is enabled or when kernel.debug is not false
+ * Adds the DebugHandler when the profiler is enabled or when kernel.debug is not false.
  *
  * @author Christophe Coevoet <stof@notk.org>
  * @author Jordi Boggiano <j.boggiano@seld.be>

--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Monolog\Logger;
 
 /**
- * Adds the DebugHandler when the profiler is enabled.
+ * Adds the DebugHandler when the profiler is enabled or when kernel.debug is not false
  *
  * @author Christophe Coevoet <stof@notk.org>
  * @author Jordi Boggiano <j.boggiano@seld.be>
@@ -35,6 +35,11 @@ class DebugHandlerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('profiler')) {
+            return;
+        }
+
+
+        if(false == $container->getParameter('kernel.debug')){
             return;
         }
 

--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -38,8 +38,7 @@ class DebugHandlerPass implements CompilerPassInterface
             return;
         }
 
-
-        if(false == $container->getParameter('kernel.debug')){
+        if (!$container->getParameter('kernel.debug')) {
             return;
         }
 


### PR DESCRIPTION
When running CLI commands with the `--no-debug` option in the dev environment, the DebugHandler was still being registered. For long running commands with lots of logging (I like to use -vvv) this will cause memory issues.

The DebugCompilerPass now checks the `kernel.debug` parameter, suggested by @fabpot in #37.

