### PR TITLE
Added resolving channel name via container parameters

### DIFF
--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -39,9 +39,11 @@ class LoggerChannelPass implements CompilerPassInterface
                     continue;
                 }
 
+                $resolvedChannel = $container->getParameterBag()->resolveValue($tag['channel']);
+
                 $definition = $container->getDefinition($id);
-                $loggerId = sprintf('monolog.logger.%s', $tag['channel']);
-                $this->createLogger($tag['channel'], $loggerId, $container);
+                $loggerId = sprintf('monolog.logger.%s', $resolvedChannel);
+                $this->createLogger($resolvedChannel, $loggerId, $container);
 
                 foreach ($definition->getArguments() as $index => $argument) {
                     if ($argument instanceof Reference && 'logger' === (string) $argument) {

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -158,6 +158,18 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         ), $container->getDefinition('monolog.handler.swift.mail_prototype')->getMethodCalls());
     }
 
+    public function testChannelParametersResolved()
+    {
+        $container = $this->getContainer('parameterized_handlers');
+
+        $this->assertEquals(
+            array(
+                'monolog.handler.custom' => array('type' => 'inclusive', 'elements' => array('some_channel')),
+            ),
+            $container->getParameter('monolog.handlers_to_channels')
+        );
+    }
+
     protected function getContainer($fixture)
     {
         $container = new ContainerBuilder();

--- a/Tests/DependencyInjection/Fixtures/xml/parameterized_handlers.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/parameterized_handlers.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:monolog="http://symfony.com/schema/dic/monolog"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <parameters>
+        <parameter key="channel_parameter">some_channel</parameter>
+    </parameters>
+
+    <services>
+        <service id="foo_logger" class="Foo">
+            <tag name="monolog.logger" channel="%channel_parameter%" />
+        </service>
+    </services>
+
+    <monolog:config>
+        <monolog:handler name="custom" type="stream" path="/tmp/symfony.log">
+            <monolog:channels>
+                <monolog:channel>%channel_parameter%</monolog:channel>
+            </monolog:channels>
+        </monolog:handler>
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/yml/parameterized_handlers.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/parameterized_handlers.yml
@@ -1,0 +1,14 @@
+parameters:
+    channel_parameter: some_channel
+
+services:
+    foo_logger:
+        class: Foo
+        tags: [{ name: monolog.logger, channel: %channel_parameter% }]
+
+monolog:
+    handlers:
+        custom:
+            type: stream
+            path: /tmp/symfony.log
+            channels: %channel_parameter%


### PR DESCRIPTION
It's a PR for #122

Now it's possible to specify channel as a parameter in a tagged configuration:

XML:

    <services>
        <service id="foo_logger" class="Foo">
            <tag name="monolog.logger" channel="%channel_parameter%" />
        </service>
    </services>

YML:

    services:
        foo_logger:
            class: Foo
            tags: [{ name: monolog.logger, channel: %channel_parameter% }]