### PR TITLE
Reference::isStrict() is gone in Symfony 3.0

### DIFF
--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -85,24 +85,6 @@ class LoggerChannelPass implements CompilerPassInterface
         }
     }
 
-    /**
-     * Creates a copy of a reference and alters the service ID.
-     *
-     * @param Reference $reference
-     * @param string    $serviceId
-     *
-     * @return Reference
-     */
-    private function changeReference(Reference $reference, $serviceId)
-    {
-        if (method_exists($reference, 'isStrict')) {
-            // Stay compatible with Symfony 2
-            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict());
-        } else {
-            return new Reference($serviceId, $reference->getInvalidBehavior());
-        }
-    }
-
     public function getChannels()
     {
         return $this->channels;
@@ -129,5 +111,23 @@ class LoggerChannelPass implements CompilerPassInterface
             $container->setDefinition($loggerId, $logger);
             $this->channels[] = $channel;
         }
+    }
+
+    /**
+     * Creates a copy of a reference and alters the service ID.
+     *
+     * @param Reference $reference
+     * @param string    $serviceId
+     *
+     * @return Reference
+     */
+    private function changeReference(Reference $reference, $serviceId)
+    {
+        if (method_exists($reference, 'isStrict')) {
+            // Stay compatible with Symfony 2
+            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict());
+        }
+
+        return new Reference($serviceId, $reference->getInvalidBehavior());
     }
 }

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -47,7 +47,7 @@ class LoggerChannelPass implements CompilerPassInterface
 
                 foreach ($definition->getArguments() as $index => $argument) {
                     if ($argument instanceof Reference && 'logger' === (string) $argument) {
-                        $definition->replaceArgument($index, new Reference($loggerId, $argument->getInvalidBehavior(), $argument->isStrict()));
+                        $definition->replaceArgument($index, $this->changeReference($argument, $loggerId));
                     }
                 }
 
@@ -55,7 +55,7 @@ class LoggerChannelPass implements CompilerPassInterface
                 foreach ($calls as $i => $call) {
                     foreach ($call[1] as $index => $argument) {
                         if ($argument instanceof Reference && 'logger' === (string) $argument) {
-                            $calls[$i][1][$index] = new Reference($loggerId, $argument->getInvalidBehavior(), $argument->isStrict());
+                            $calls[$i][1][$index] = $this->changeReference($argument, $loggerId);
                         }
                     }
                 }
@@ -82,6 +82,24 @@ class LoggerChannelPass implements CompilerPassInterface
                 }
                 $logger->addMethodCall('pushHandler', array(new Reference($handler)));
             }
+        }
+    }
+
+    /**
+     * Creates a copy of a reference and alters the service ID.
+     *
+     * @param Reference $reference
+     * @param string    $serviceId
+     *
+     * @return Reference
+     */
+    private function changeReference(Reference $reference, $serviceId)
+    {
+        if (method_exists($reference, 'isStrict')) {
+            // Stay compatible with Symfony 2
+            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict());
+        } else {
+            return new Reference($serviceId, $reference->getInvalidBehavior());
         }
     }
 


### PR DESCRIPTION
The `LoggerChannelPass` contains calls to `Symfony\Component\DependencyInjection\Reference::isStrict()`, a method that has been removed from Symfony 3. The test case `LoggerChannelPassTest` fails if you run it against the Symfony master branch.

This pull request adds a forward-compatible code that checks with `method_exists()` if the method is still present. That check may be removed in the future, as soon as support for Symfony 2 is dropped. Tests are now running green with Symfony 2.7.4 and 3.0-dev.