### PR TITLE
Default swiftmailer transport was always used

### DIFF
--- a/DependencyInjection/Compiler/AddSwiftMailerTransportPass.php
+++ b/DependencyInjection/Compiler/AddSwiftMailerTransportPass.php
@@ -33,21 +33,23 @@ class AddSwiftMailerTransportPass implements CompilerPassInterface
         foreach ($handlers as $id) {
             $definition = $container->getDefinition($id);
 
+            $mailerId = $definition->getArgument(0)->_toString();
+
             if (
-                $container->hasAlias('swiftmailer.transport.real') ||
-                $container->hasDefinition('swiftmailer.transport.real')
+                $container->hasAlias($mailerId . '.transport.real') ||
+                $container->hasDefinition($mailerId . '.transport.real')
             ) {
                 $definition->addMethodCall(
                     'setTransport',
-                    array(new Reference('swiftmailer.transport.real'))
+                    array(new Reference($mailerId . '.transport.real'))
                 );
             } elseif (
-                $container->hasAlias('swiftmailer.transport') ||
-                $container->hasDefinition('swiftmailer.transport')
+                $container->hasAlias($mailerId . '.transport') ||
+                $container->hasDefinition($mailerId . '.transport')
             ) {
                 $definition->addMethodCall(
                     'setTransport',
-                    array(new Reference('swiftmailer.transport'))
+                    array(new Reference($mailerId . '.transport'))
                 );
             }
         }


### PR DESCRIPTION
The transport of the default mailer was always used, even if the monolog handler
has a different mailer setting. When using a non-default mailer, the correct transport
was never called and the monolog emails never sent.

Instead of assuming the default mailer transport, I now set the transport of the used
mailer.

Fixes #137.