### PR TITLE
Disable sentry's default integrations when using it

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -681,7 +681,10 @@ class MonologExtension extends Extension
             } else {
                 $options = new Definition(
                     'Sentry\\Options',
-                    [['dsn' => $handler['dsn']]]
+                    [[
+                        'dsn' => $handler['dsn'],
+                        'default_integrations' => false, // prevent sentry from registering shutdown functions
+                    ]]
                 );
 
                 if (!empty($handler['environment'])) {
@@ -709,9 +712,6 @@ class MonologExtension extends Extension
                 'Sentry\\State\\Hub',
                 [new Reference($clientId)]
             );
-
-            // can't set the hub to the current hub, getting into a recursion otherwise...
-            //$hub->addMethodCall('setCurrent', array($hub));
 
             $definition->setArguments([
                 $hub,


### PR DESCRIPTION
Monolog already does it, as the request integration that comes with the default configuration of sentry.

Disabling it fixes it. Maybe we should add a marker that says we could activate it ? I doubt the interest but I could be wrong.

poke @B-Galati 