### PR TITLE
Adding exclude_fields in the configuration of slack handlers

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -267,6 +267,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *   - [timeout]: float
  *   - [connection_timeout]: float
+ *   - [exclude_fields]: array, defaults to empty array
  *
  * - slackwebhook:
  *   - webhook_url: slack webhook URL
@@ -278,6 +279,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [include_extra]: bool, defaults to false
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [exclude_fields]: array, defaults to empty array
  *
  * - slackbot:
  *   - team: slack team slug
@@ -546,6 +548,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('use_attachment')->defaultTrue()->end() // slack & slackwebhook
                 ->scalarNode('use_short_attachment')->defaultFalse()->end() // slack & slackwebhook
                 ->scalarNode('include_extra')->defaultFalse()->end() // slack & slackwebhook
+                ->variableNode('exclude_fields')->defaultValue([])->end() // slack & slackwebhook
                 ->scalarNode('icon_emoji')->defaultNull()->end() // slack & slackwebhook
                 ->scalarNode('webhook_url')->end() // slackwebhook
                 ->scalarNode('team')->end() // slackbot

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -664,6 +664,7 @@ class MonologExtension extends Extension
                     $handler['bubble'],
                     $handler['use_short_attachment'],
                     $handler['include_extra'],
+                    $handler['exclude_fields'],
                 ]);
                 if (isset($handler['timeout'])) {
                     $definition->addMethodCall('setTimeout', [$handler['timeout']]);
@@ -684,6 +685,7 @@ class MonologExtension extends Extension
                     $handler['include_extra'],
                     $handler['level'],
                     $handler['bubble'],
+                    $handler['exclude_fields'],
                 ]);
                 break;
 


### PR DESCRIPTION
Add configuration :
`exclude_fields` => Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']

cf. https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/SlackHandler.php