### PR TITLE
Allow using `OutputInterface::VERBOSITY_*` constants in PHP config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -1015,10 +1016,13 @@ class Configuration implements ConfigurationInterface
                         ->then(function ($v) {
                             $map = [];
                             $verbosities = ['VERBOSITY_QUIET', 'VERBOSITY_NORMAL', 'VERBOSITY_VERBOSE', 'VERBOSITY_VERY_VERBOSE', 'VERBOSITY_DEBUG'];
-                            // allow numeric indexed array with ascendning verbosity and lowercase names of the constants
+                            $verbosityConstants = [OutputInterface::VERBOSITY_QUIET, OutputInterface::VERBOSITY_NORMAL, OutputInterface::VERBOSITY_VERBOSE, OutputInterface::VERBOSITY_VERY_VERBOSE, OutputInterface::VERBOSITY_DEBUG];
+                            // allow numeric indexed array with ascending verbosity and lowercase names of the constants
                             foreach ($v as $verbosity => $level) {
                                 if (is_int($verbosity) && isset($verbosities[$verbosity])) {
                                     $map[$verbosities[$verbosity]] = strtoupper($level);
+                                } elseif (is_int($verbosity) && false !== $i = \array_search($verbosity, $verbosityConstants, true)) {
+                                    $map[$verbosities[$i]] = strtoupper($level);
                                 } else {
                                     $map[strtoupper($verbosity)] = strtoupper($level);
                                 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -267,18 +267,17 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('-100', $config['handlers']['telegram']['channel']);
     }
 
-    public function testWithConsoleHandler()
+    /**
+     * @dataProvider provideConsoleHandlerCases
+     */
+    public function testWithConsoleHandler(array $verbosityLevels, array $expectedVerbosityMap)
     {
         $configs = [
             [
                 'handlers' => [
                     'console' => [
                         'type' => 'console',
-                        'verbosity_levels' => [
-                            'VERBOSITY_NORMAL' => 'NOTICE',
-                            'verbosity_verbose' => 'info',
-                            'VERBOSITY_very_VERBOSE' => '200'
-                        ]
+                        'verbosity_levels' => $verbosityLevels
                     ]
                 ]
             ]
@@ -287,13 +286,39 @@ class ConfigurationTest extends TestCase
         $config = $this->process($configs);
 
         $this->assertSame('console', $config['handlers']['console']['type']);
-        $this->assertSame([
-            OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
-            OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
-            OutputInterface::VERBOSITY_VERY_VERBOSE => 200,
-            OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
-            OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
-            ], $config['handlers']['console']['verbosity_levels']);
+        $this->assertSame($expectedVerbosityMap, $config['handlers']['console']['verbosity_levels']);
+    }
+
+    public function provideConsoleHandlerCases(): iterable
+    {
+        yield 'with strings only' => [
+            [
+                'VERBOSITY_NORMAL' => 'NOTICE',
+                'verbosity_verbose' => 'info',
+                'VERBOSITY_very_VERBOSE' => '200'
+            ],
+            [
+                OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
+                OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
+                OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::INFO,
+                OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
+                OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
+            ]
+        ];
+        yield 'with constants' => [
+            [
+                OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
+                'verbosity_verbose' => 'info',
+                OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::INFO
+            ],
+            [
+                OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
+                OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
+                OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::INFO,
+                OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
+                OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
+            ]
+        ];
     }
 
     public function testWithType()


### PR DESCRIPTION
While trying to improve some configuration blocks in Symfony docs, I found out that it was not possible to use constants for the verbosity levels of the console handler.
I think it's missing now that we tend to spread PHP config files such as `config/packages/monolog.php`.

Before this patch one gets the following exception:
```
Symfony\Component\Config\Definition\Exception\InvalidConfigurationException: Unrecognized options "32, 128" under "monolog.handlers.console.verbosity_levels". Available options are "VERBOSITY_DEBUG", "VERBOSITY_NORMAL", "VERBOSITY_QUIET", "VERBOSITY_VERBOSE", "VERBOSITY_VERY_VERBOSE".
```