### PR TITLE
Allow to use env var for log levels of console logger

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1047,19 +1047,6 @@ class Configuration implements ConfigurationInterface
                                     ));
                                 }
 
-                                try {
-                                    if (Logger::API === 3) {
-                                        $level = Logger::toMonologLevel($level)->value;
-                                    } else {
-                                        $level = Logger::toMonologLevel(is_numeric($level) ? (int) $level : $level);
-                                    }
-                                } catch (\Psr\Log\InvalidArgumentException $e) {
-                                    throw new InvalidConfigurationException(sprintf(
-                                        'The configured minimum log level "%s" for verbosity "%s" is invalid as it is not defined in Monolog\Logger.',
-                                         $level, $verbosity
-                                    ));
-                                }
-
                                 $map[constant($verbosityConstant)] = $level;
                             }
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -278,7 +278,7 @@ class ConfigurationTest extends TestCase
                         'verbosity_levels' => [
                             'VERBOSITY_NORMAL' => 'NOTICE',
                             'verbosity_verbose' => 'info',
-                            'VERBOSITY_very_VERBOSE' => '200'
+                            'VERBOSITY_very_VERBOSE' => '200',
                         ]
                     ]
                 ]
@@ -289,11 +289,11 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame('console', $config['handlers']['console']['type']);
         $this->assertSame([
-            OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
-            OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
-            OutputInterface::VERBOSITY_VERY_VERBOSE => 200,
-            OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
-            OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
+            OutputInterface::VERBOSITY_NORMAL => 'NOTICE',
+            OutputInterface::VERBOSITY_VERBOSE => 'INFO',
+            OutputInterface::VERBOSITY_VERY_VERBOSE => '200',
+            OutputInterface::VERBOSITY_QUIET => 'ERROR',
+            OutputInterface::VERBOSITY_DEBUG => 'DEBUG',
             ], $config['handlers']['console']['verbosity_levels']);
     }
 


### PR DESCRIPTION
Following https://github.com/symfony/monolog-bundle/pull/446

The console logger have a map of verbosity => log level that should be configurable with env vars.

Disadvantage: in case of invalid log level, the exception cannot be contextualized with the output verbosity.

The tests in this PR will conflict with https://github.com/symfony/monolog-bundle/pull/439