### PR TITLE
Add `handler_default_channels` configuration option

### DIFF
--- a/config/schema/monolog-1.0.xsd
+++ b/config/schema/monolog-1.0.xsd
@@ -11,6 +11,7 @@
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="handler" type="handler" />
             <xsd:element name="channel" type="xsd:string" />
+            <xsd:element name="handler-default-channels" type="channels" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
     </xsd:complexType>
 
@@ -93,6 +94,7 @@
         <xsd:attribute name="webhook-url" type="xsd:string" />
         <xsd:attribute name="slack-team" type="xsd:string" />
         <xsd:attribute name="region" type="xsd:string" />
+        <xsd:attribute name="use-default-channels" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -390,6 +390,8 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('monolog');
         $rootNode = $treeBuilder->getRootNode();
 
+        $this->addChannelsSection($rootNode, 'handler_default_channels');
+
         $handlers = $rootNode
             ->fixXmlConfig('channel')
             ->fixXmlConfig('handler')
@@ -634,6 +636,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('formatter')->end()
                 ->booleanNode('nested')->defaultFalse()->end()
+                ->booleanNode('use_default_channels')->defaultTrue()->end()
             ->end();
 
         $this->addGelfSection($handlerNode);
@@ -1086,11 +1089,11 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addChannelsSection(ArrayNodeDefinition $handlerNode)
+    private function addChannelsSection(ArrayNodeDefinition $handlerNode, string $nodeName = 'channels')
     {
         $handlerNode
             ->children()
-                ->arrayNode('channels')
+                ->arrayNode($nodeName)
                     ->fixXmlConfig('channel', 'elements')
                     ->canBeUnset()
                     ->beforeNormalization()
@@ -1106,7 +1109,7 @@ class Configuration implements ConfigurationInterface
                         ->thenUnset()
                     ->end()
                     ->validate()
-                        ->always(function ($v) {
+                        ->always(function ($v) use ($nodeName) {
                             $isExclusive = null;
                             if (isset($v['type'])) {
                                 $isExclusive = 'exclusive' === $v['type'];
@@ -1116,13 +1119,13 @@ class Configuration implements ConfigurationInterface
                             foreach ($v['elements'] as $element) {
                                 if (0 === strpos($element, '!')) {
                                     if (false === $isExclusive) {
-                                        throw new InvalidConfigurationException('Cannot combine exclusive/inclusive definitions in channels list.');
+                                        throw new InvalidConfigurationException(\sprintf('Cannot combine exclusive/inclusive definitions in %s list.', $nodeName));
                                     }
                                     $elements[] = substr($element, 1);
                                     $isExclusive = true;
                                 } else {
                                     if (true === $isExclusive) {
-                                        throw new InvalidConfigurationException('Cannot combine exclusive/inclusive definitions in channels list');
+                                        throw new InvalidConfigurationException(\sprintf('Cannot combine exclusive/inclusive definitions in %s list', $nodeName));
                                     }
                                     $elements[] = $element;
                                     $isExclusive = false;
@@ -1141,7 +1144,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('type')
                             ->validate()
                                 ->ifNotInArray(['inclusive', 'exclusive'])
-                                ->thenInvalid('The type of channels has to be inclusive or exclusive')
+                                ->thenInvalid(\sprintf('The type of %s has to be inclusive or exclusive', $nodeName))
                             ->end()
                         ->end()
                         ->arrayNode('elements')

--- a/tests/DependencyInjection/Fixtures/xml/handlers_with_default_channels.xml
+++ b/tests/DependencyInjection/Fixtures/xml/handlers_with_default_channels.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:monolog="http://symfony.com/schema/dic/monolog"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <monolog:config>
+        <monolog:channel>foo</monolog:channel>
+        <monolog:channel>bar</monolog:channel>
+        <monolog:channel>baz</monolog:channel>
+
+        <monolog:handler-default-channels>
+            <monolog:channel>!foo</monolog:channel>
+            <monolog:channel>!bar</monolog:channel>
+        </monolog:handler-default-channels>
+
+        <monolog:handler name="one" type="stream" use-default-channels="true">
+            <monolog:channels>
+                <monolog:channel>foo</monolog:channel>
+            </monolog:channels>
+        </monolog:handler>
+        <monolog:handler name="two" type="stream" use-default-channels="false">
+            <monolog:channels>
+                <monolog:channel>!bar</monolog:channel>
+                <monolog:channel>!baz</monolog:channel>
+            </monolog:channels>
+        </monolog:handler>
+        <monolog:handler name="three" type="stream" use-default-channels="true">
+            <monolog:channels>
+                <monolog:channel>!bar</monolog:channel>
+                <monolog:channel>!baz</monolog:channel>
+            </monolog:channels>
+        </monolog:handler>
+        <monolog:handler name="four" type="stream" use-default-channels="true" />
+        <monolog:handler name="five" type="stream" use-default-channels="false" />
+        <monolog:handler name="six" type="stream" />
+    </monolog:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/handlers_with_default_channels.yml
+++ b/tests/DependencyInjection/Fixtures/yml/handlers_with_default_channels.yml
@@ -1,0 +1,24 @@
+monolog:
+    channels: [ 'foo', 'bar', 'baz' ]
+    handler_default_channels: [ '!foo', '!bar' ]
+    handlers:
+        one:
+            type: stream
+            use_default_channels: true
+            channels: foo
+        two:
+            type: stream
+            use_default_channels: false
+            channels: [ '!bar', '!baz' ]
+        three:
+            type: stream
+            use_default_channels: true
+            channels: [ '!bar', '!baz' ]
+        four:
+            type: stream
+            use_default_channels: true
+        five:
+            type: stream
+            use_default_channels: false
+        six:
+            type: stream


### PR DESCRIPTION
When configuring multiple handlers, one annoying problem I often come across is having to add every channel that is meant to be used with a specific handler to all handlers with an exclusive list, eg:

```yaml
monolog:
    handlers:
        main:
            type: fingers_crossed
            action_level: error
            handler: nested
            channels: [ "!one", "!two", "!three" ]
        nested:
            type: stream
            path: php://stderr
            level: debug
            formatter: monolog.formatter.json
        console:
            type: console
            process_psr_3_messages: false
            channels: [ "!event", "!doctrine", "!one", "!two", "!three" ]
```

The idea behind this PR is to be able to set a list of default channels that is applied to all handlers.

```diff
monolog:
+   handler_default_channels: [ "!one", "!two", "!three" ]
    handlers:
        main:
            type: fingers_crossed
            action_level: error
            handler: nested
-           channels: [ "!one", "!two", "!three" ]
        nested:
            type: stream
            path: php://stderr
            level: debug
            formatter: monolog.formatter.json
        console:
            type: console
            process_psr_3_messages: false
-           channels: [ "!event", "!doctrine", "!one", "!two", "!three" ]
+           channels: [ "!event", "!doctrine" ]
```

If a handler has a list of its own and it's the same type as the default one (inclusive/exclusive) the two lists are merged. If the handler's list is a different type, it replaces the default one. Handlers without lists inherit the default one. A `use_default_channels` handler option was also added so that a certain handler can choose not to use the default list.

   ```yaml
    monolog:
        handler_default_channels: [ "!one", "!two", "!three" ]
        handlers:
            one:
                # ...
                channels: [ "one", "four" ] # final list: ["one", "four"]
            two:
                # ...
                use_default_channels: false
                channels: [ "one", "four" ] # final list: ["one", "four"]
            three:
                # ...
                channels: [ "!two", "!three", "!four" ] # final list: ["!one", "!two", "!three", "!four"]
            four:
                # ...
                use_default_channels: false
                channels: [ "!two", "!three", "!four" ] # final list: ["!two", "!three", "!four"]
            five:
                # ...
                # final list: ["!one", "!two", "!three"]
   ```
   ```yaml
    monolog:
        handler_default_channels: [ "one", "two", "three" ]
        handlers:
            one:
                # ...
                channels: [ "one", "four" ] # final list: ["one", "two", "three", "four"]
            two:
                # ...
                use_default_channels: false
                channels: [ "one", "four" ] # final list: ["one", "four"]
            three:
                # ...
                channels: [ "!two", "!three", "!four" ] # final list: ["!two", "!three", "!four"]
            four:
                # ...
                use_default_channels: false
                channels: [ "!two", "!three", "!four" ] # final list: ["!two", "!three", "!four"]
            five:
            # ...
            # final list: ["one", "two", "three"]
   ```