### PR TITLE
Add support for additional parameters in native mailer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,6 +197,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *   - [headers]: optional array containing additional headers: ['Foo: Bar', '...']
+ *   - [parameters]: optional array containing additional parameters: ['--for bar', '...']
  *
  * - symfony_mailer:
  *   - from_email: optional if email_prototype is given
@@ -429,6 +430,7 @@ class Configuration implements ConfigurationInterface
                 ->fixXmlConfig('tag')
                 ->fixXmlConfig('accepted_level')
                 ->fixXmlConfig('header')
+                ->fixXmlConfig('parameter')
                 ->canBeUnset();
 
         $handlerNode
@@ -973,6 +975,10 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('subject')->end() // swift_mailer, native_mailer and symfony_mailer
                 ->scalarNode('content_type')->defaultNull()->end() // swift_mailer and symfony_mailer
                 ->arrayNode('headers') // native_mailer
+                    ->canBeUnset()
+                    ->scalarPrototype()->end()
+                ->end()
+                ->arrayNode('parameters') // native_mailer
                     ->canBeUnset()
                     ->scalarPrototype()->end()
                 ->end()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -576,6 +576,9 @@ class MonologExtension extends Extension
             if (!empty($handler['headers'])) {
                 $definition->addMethodCall('addHeader', [$handler['headers']]);
             }
+            if (!empty($handler['parameters'])) {
+                $definition->addMethodCall('addParameter', [$handler['parameters']]);
+            }
             break;
 
         case 'symfony_mailer':

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -29,6 +29,7 @@
             <xsd:element name="accepted-level" type="level" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="to-email" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="header" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="parameter" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="process-psr-3-messages" type="process-psr-3-messages" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="type" type="xsd:string" />

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -306,8 +306,9 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $logger = $container->getDefinition('monolog.handler.mailer');
         $methodCalls = $logger->getMethodCalls();
 
-        $this->assertCount(2, $methodCalls);
+        $this->assertCount(3, $methodCalls);
         $this->assertSame(['addHeader', [['Foo: bar', 'Baz: inga']]], $methodCalls[1]);
+        $this->assertSame(['addParameter', [['--foo bar', '--baz inga']]], $methodCalls[2]);
     }
 
     protected function getContainer($fixture)

--- a/Tests/DependencyInjection/Fixtures/xml/native_mailer.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/native_mailer.xml
@@ -10,6 +10,8 @@
         <handler name="mailer" type="native_mailer" to-email="foo@example.com" from-email="bar@example.com" subject="a subject">
             <header>Foo: bar</header>
             <header>Baz: inga</header>
+            <parameter>--foo bar</parameter>
+            <parameter>--baz inga</parameter>
         </handler>
     </config>
 </srv:container>

--- a/Tests/DependencyInjection/Fixtures/yml/native_mailer.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/native_mailer.yml
@@ -8,3 +8,6 @@ monolog:
             headers:
                 - "Foo: bar"
                 - "Baz: inga"
+            parameters:
+                - "--foo bar"
+                - "--baz inga"


### PR DESCRIPTION
This PR adds support for additional parameters to the native mailer, as describe in https://www.php.net/manual/en/function.mail.php

> The additional_params parameter can be used to pass additional flags as command line options to the program configured to be used when sending mail, as defined by the sendmail_path configuration setting. For example, this can be used to set the envelope sender address when using sendmail with the -f sendmail option. 

In a recent project we had the requirement to set the additional parameter `-ftest@example.com` to be able to send emails through a relay server. Otherwise the mails were bounced.

The bundle currently allows to set these parameters only on existing logger instances. This PR allows to set them in the configuration file:

```yaml
native_mailer:
    type: native_mailer
    from_email: 'from@example.com'
    to_email: 'to@example.com'
    subject: 'Example subject'
    parameters:
        - '-ftest@example.com'
```