### PR TITLE
Add service definition for SyslogFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add `enabled` option to `handlers` configuration
 * Add `priority` field to `processor` tag
 * Add `mongodb` handler and deprecate `mongo`
+* Add `monolog.formatter.syslog` service definition to format RFC5424-compliant messages
 
 ## 3.10.0 (2023-11-06)
 

--- a/config/monolog.php
+++ b/config/monolog.php
@@ -20,6 +20,7 @@ use Monolog\Formatter\LogglyFormatter;
 use Monolog\Formatter\LogstashFormatter;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Formatter\ScalarFormatter;
+use Monolog\Formatter\SyslogFormatter;
 use Monolog\Formatter\WildfireFormatter;
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Logger;
@@ -55,6 +56,7 @@ return static function (ContainerConfigurator $container) {
         ->set('monolog.formatter.html', HtmlFormatter::class)
         ->set('monolog.formatter.json', JsonFormatter::class)
         ->set('monolog.formatter.line', LineFormatter::class)
+        ->set('monolog.formatter.syslog', SyslogFormatter::class)
         ->set('monolog.formatter.loggly', LogglyFormatter::class)
         ->set('monolog.formatter.normalizer', NormalizerFormatter::class)
         ->set('monolog.formatter.scalar', ScalarFormatter::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/monolog-bundle/issues/441
| License       | MIT

From https://github.com/symfony/recipes/issues/1111 & https://github.com/Seldaek/monolog/pull/1689 I found out about the (newish) syslog formatter that can be viewed nicely with lnav. While trying to use it, I see there is no service created for this in monolog-bundle. Users can obviously make their own service in their app's services.yaml, but seeing other formatters exposed and discussion about adding it via recipe, I thought it would be good idea to create the service from monolog-bundle.