### PR TITLE
Add enabled parameter in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Deprecate `sentry` and `raven` handler, use a `service` handler with [`sentry/sentry-symfony`](https://docs.sentry.io/platforms/php/guides/symfony/logs/) instead
 * Add configuration for Gelf encoders
 * Fix `host` configuration for `elastic_search` handler
+* Add `enabled` option to `handlers` configuration
 
 ## 3.10.0 (2023-11-06)
 

--- a/config/schema/monolog-1.0.xsd
+++ b/config/schema/monolog-1.0.xsd
@@ -93,6 +93,7 @@
         <xsd:attribute name="webhook-url" type="xsd:string" />
         <xsd:attribute name="slack-team" type="xsd:string" />
         <xsd:attribute name="region" type="xsd:string" />
+        <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -457,6 +457,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('id')->end() // service & rollbar
+                ->booleanNode('enabled')->defaultTrue()->end()
                 ->scalarNode('priority')->defaultValue(0)->end()
                 ->scalarNode('level')->defaultValue('DEBUG')->end()
                 ->booleanNode('bubble')->defaultTrue()->end()

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -67,6 +67,9 @@ class MonologExtension extends Extension
             $handlers = [];
 
             foreach ($config['handlers'] as $name => $handler) {
+                if (!$handler['enabled']) {
+                    continue;
+                }
                 $handlers[$handler['priority']][] = [
                     'id' => $this->buildHandler($container, $name, $handler),
                     'channels' => empty($handler['channels']) ? null : $handler['channels'],

--- a/tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
+use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -231,6 +232,31 @@ class LoggerChannelPassTest extends TestCase
         $container->getCompilerPassConfig()->setRemovingPasses([]);
 
         return $container;
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testEnabledHandler(bool $enabled)
+    {
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $config = [
+            'handlers' => [
+                'main' => [
+                    'enabled' => $enabled,
+                    'type' => 'stream',
+                    'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                    'level' => 'debug',
+                ],
+            ],
+        ];
+
+        $loader->load([$config], $container);
+
+        $this->assertSame($enabled, $container->hasDefinition('monolog.handler.main'));
     }
 }
 

--- a/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
+++ b/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
@@ -253,7 +253,7 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertNotContainsEquals(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should not be enabled');
     }
 
-    public function testPsrLogMessageProcessorHasConstructorArguments(): void
+    public function testPsrLogMessageProcessorHasConstructorArguments()
     {
         $reflectionConstructor = (new \ReflectionClass(PsrLogMessageProcessor::class))->getConstructor();
         if (null === $reflectionConstructor || $reflectionConstructor->getNumberOfParameters() <= 0) {
@@ -280,7 +280,7 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         }
     }
 
-    public function testPsrLogMessageProcessorDoesNotHaveConstructorArguments(): void
+    public function testPsrLogMessageProcessorDoesNotHaveConstructorArguments()
     {
         $reflectionConstructor = (new \ReflectionClass(PsrLogMessageProcessor::class))->getConstructor();
         if (null !== $reflectionConstructor && $reflectionConstructor->getNumberOfParameters() > 0) {
@@ -321,6 +321,15 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
 
         $this->assertSame(NullHandler::class, $logger->getClass());
         $this->assertSame('DEBUG', $logger->getArgument(0));
+    }
+
+    public function testEnabledHandleOption()
+    {
+        $container = $this->getContainer('enabled_handlers');
+
+        $this->assertTrue($container->hasDefinition('monolog.handler.default'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.enabled'));
+        $this->assertFalse($container->hasDefinition('monolog.handler.disabled'));
     }
 
     protected function getContainer($fixture)

--- a/tests/DependencyInjection/Fixtures/xml/enabled_handlers.xml
+++ b/tests/DependencyInjection/Fixtures/xml/enabled_handlers.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:monolog="http://symfony.com/schema/dic/monolog"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <monolog:config>
+        <monolog:handler name="default" type="stream" path="/tmp/symfony.log"/>
+        <monolog:handler name="enabled" type="stream" path="/tmp/symfony.log" enabled="true"/>
+        <monolog:handler name="disabled" type="stream" path="/tmp/symfony.log" enabled="false"/>
+    </monolog:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/enabled_handlers.yml
+++ b/tests/DependencyInjection/Fixtures/yml/enabled_handlers.yml
@@ -1,0 +1,13 @@
+monolog:
+    handlers:
+        default:
+            type: stream
+            path: /tmp/symfony.log
+        enabled:
+            type: stream
+            path: /tmp/symfony.log
+            enabled: true
+        disabled:
+            type: stream
+            path: /tmp/symfony.log
+            enabled: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


This feature aims to separate the enabling of handlers based on the environment.

## Use Case :

You have 3 servers on your project : dev, staging, and prod
- On your **dev** machine, you are in the **dev** environment.
- On your **staging** server, you are in the **prod** environment.
- On your **prod** server, you are in the **prod** environment.

Currently, you can't disable handlers for a specific environment. For an instance, you can't disable logging only in your staging environment.

With the enabled parameter, you are able to disable logging only in the staging environment.