### PR TITLE
Add 'exclude_fields' param to Slack handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Reorganize files to match the "Reusable Bundles" structure
 * Migrate services configuration to PHP
 * Add `console.interactive_only` flag
+* Add `slack.exclude_fields` and `slackwebhook.exclude_fields` configuration
 
 ## 3.10.0 (2023-11-06)
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -269,6 +269,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *   - [timeout]: float
  *   - [connection_timeout]: float
+ *   - [exclude_fields]: list of excluded fields, defaults to empty array
  *
  * - slackwebhook:
  *   - webhook_url: slack webhook URL
@@ -280,6 +281,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [include_extra]: bool, defaults to false
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [exclude_fields]: list of excluded fields, defaults to empty array
  *
  * - slackbot:
  *   - team: slack team slug
@@ -551,6 +553,10 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('include_extra')->defaultFalse()->end() // slack & slackwebhook
                 ->scalarNode('icon_emoji')->defaultNull()->end() // slack & slackwebhook
                 ->scalarNode('webhook_url')->end() // slackwebhook
+                ->arrayNode('exclude_fields')
+                    ->canBeUnset()
+                    ->prototype('scalar')->end()
+                ->end() // slack & slackwebhook
                 ->scalarNode('team')->end() // slackbot
                 ->scalarNode('notify')->defaultFalse()->end() // hipchat
                 ->scalarNode('nickname')->defaultValue('Monolog')->end() // hipchat

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -665,6 +665,7 @@ class MonologExtension extends Extension
                     $handler['bubble'],
                     $handler['use_short_attachment'],
                     $handler['include_extra'],
+                    $handler['exclude_fields'],
                 ]);
                 if (isset($handler['timeout'])) {
                     $definition->addMethodCall('setTimeout', [$handler['timeout']]);
@@ -685,6 +686,7 @@ class MonologExtension extends Extension
                     $handler['include_extra'],
                     $handler['level'],
                     $handler['bubble'],
+                    $handler['exclude_fields'],
                 ]);
                 break;
 


### PR DESCRIPTION
The optional 'exclude_fields' param is being added to the Slack handler in this PR.

See the SlackHandler [constructor](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/SlackHandler.php#L59) in the Monolog repo.