### PR TITLE
Add Sentry `BreadcrumbHandler` support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -236,6 +236,9 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - hub_id: Sentry hub custom service id (optional)
  *   - [fill_extra_context]: bool, defaults to false
  *
+ * - sentry_breadcrumb:
+ *   - sentry_handler: the sentry handler's name
+ *
  * - newrelic:
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
@@ -584,6 +587,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('persistent')->end() // socket_handler
                 ->scalarNode('dsn')->end() // raven_handler, sentry_handler
                 ->scalarNode('hub_id')->defaultNull()->end() // sentry_handler
+                ->scalarNode('sentry_handler')->defaultNull()->end() // sentry_breadcrumb
                 ->scalarNode('client_id')->defaultNull()->end() // raven_handler, sentry_handler
                 ->scalarNode('auto_log_stacks')->defaultFalse()->end() // raven_handler
                 ->scalarNode('release')->defaultNull()->end() // raven_handler, sentry_handler
@@ -724,6 +728,10 @@ class Configuration implements ConfigurationInterface
             ->validate()
                 ->ifTrue(function ($v) { return 'sentry' === $v['type'] && null !== $v['hub_id'] && null !== $v['client_id']; })
                 ->thenInvalid('You can not use both a hub_id and a client_id in a Sentry handler')
+            ->end()
+            ->validate()
+                ->ifTrue(function ($v) { return 'sentry_breadcrumb' === $v['type'] && !$v['sentry_handler']; })
+                ->thenInvalid('The sentry_handler has to be specified to use a Sentry BreadcrumbHandler')
             ->end()
             ->validate()
                 ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && (empty($v['token']) || empty($v['room'])); })

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -511,6 +511,51 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         );
     }
 
+    public function testSentryBreadcrumbHandlerWhenConfigurationIsWrong()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The sentry_handler has to be specified to use a Sentry BreadcrumbHandler');
+
+        $this->getContainer([['handlers' => ['sentry_breadcrumb' => ['type' => 'sentry_breadcrumb']]]]);
+    }
+
+    /**
+     * @testWith [{"dsn": "http://a:b@c.com:9000/1"}, "monolog.handler.sentry.hub"]
+     *           [{"hub_id": "sentry.hub"}, "sentry.hub"]
+     */
+    public function testSentryBreadcrumbHandlerWhenConfigurationIsOk(array $config, string $hubId)
+    {
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'sentry_breadcrumb' => ['type' => 'sentry_breadcrumb', 'sentry_handler' => 'sentry'],
+                        'sentry' => ['type' => 'sentry'] + $config,
+                    ],
+                ],
+            ],
+            [
+                'sentry.hub' => new Definition(\Sentry\State\HubInterface::class),
+            ]
+        );
+
+        $this->assertTrue($container->hasDefinition('monolog.logger'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.sentry'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.sentry_breadcrumb'));
+
+        $logger = $container->getDefinition('monolog.logger');
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.sentry')]);
+        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', [new Reference('monolog.handler.sentry_breadcrumb')]);
+
+        $handler = $container->getDefinition('monolog.handler.sentry_breadcrumb');
+        $this->assertDICDefinitionClass($handler, 'Sentry\Monolog\BreadcrumbHandler');
+        $this->assertDICConstructorArguments($handler, [new Reference($hubId), 'DEBUG', true]);
+
+        $sentry = $container->getDefinition('monolog.handler.sentry');
+        $this->assertSame((string) $sentry->getArgument(0), (string) $handler->getArgument(0));
+    }
+
     public function testLogglyHandler()
     {
         $token = '026308d8-2b63-4225-8fe9-e01294b6e472';


### PR DESCRIPTION
Adds support for https://github.com/getsentry/sentry-php/pull/1199.

```yaml
monolog:
  handlers:
    sentry:
      type: sentry
      hub_id: Sentry\State\HubInterface
      level: !php/const Monolog\Logger::ERROR
    sentry_breadcrumb:
      type: sentry_breadcrumb
      sentry_handler: sentry
      level: !php/const Monolog\Logger::INFO

# or if you don't have Sentry bundle installed

monolog:
  handlers:
    sentry:
      type: sentry
      dsn: "https://public@sentry.example.com/1"
      level: !php/const Monolog\Logger::ERROR
    sentry_breadcrumb:
      type: sentry_breadcrumb
      sentry_handler: sentry
      level: !php/const Monolog\Logger::INFO
```

Initially, I considered using the existing `handler` option instead of introducing the new `sentry_handler` option. However, I decided against it because the PSR logger doesn't get auto-enabled when the `handler` option is used:

https://github.com/symfony/monolog-bundle/blob/ed0e4a287282971d110fd8c99d9ac391559a43ce/DependencyInjection/MonologExtension.php#L179-L183