### PR TITLE
Add support for configuring Gelf encoders in Monolog configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Drop support for Symfony < 6.4
 * Add TelegramBotHandler `topic` support
 * Deprecate `sentry` and `raven` handler, use a `service` handler with [`sentry/sentry-symfony`](https://docs.sentry.io/platforms/php/guides/symfony/logs/) instead
+* Add configuration for Gelf encoders
 
 ## 3.10.0 (2023-11-06)
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -839,7 +839,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('hostname')->end()
                         ->scalarNode('port')->defaultValue(12201)->end()
                         ->scalarNode('chunk_size')->defaultValue(1420)->end()
-                        ->scalarNode('encoder')->end()
+                        ->enumNode('encoder')->values(['json', 'compressed_json'])->end()
                     ->end()
                     ->validate()
                         ->ifTrue(function ($v) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -52,7 +52,12 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *
  * - gelf:
- *   - publisher: {id: ...} or {hostname: ..., port: ..., chunk_size: ...}
+ *   - publiser:
+ *      - id: string, service id of a publisher implementation, optional if hostname is given
+ *      - hostname: string, optional if id is given
+ *      - [port]: int, defaults to 12201
+ *      - [chunk_size]: int, defaults to 1420
+ *      - [encoder]: string, its value can be 'json' or 'compressed_json'
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *
@@ -831,6 +836,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('hostname')->end()
                         ->scalarNode('port')->defaultValue(12201)->end()
                         ->scalarNode('chunk_size')->defaultValue(1420)->end()
+                        ->scalarNode('encoder')->end()
                     ->end()
                     ->validate()
                         ->ifTrue(function ($v) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -52,14 +52,17 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *
  * - gelf:
- *   - publisher:
- *      - id: string, service id of a publisher implementation, optional if hostname is given
- *      - hostname: string, optional if id is given
- *      - [port]: int, defaults to 12201
- *      - [chunk_size]: int, defaults to 1420
- *      - [encoder]: string, its value can be 'json' or 'compressed_json'
- *   - [level]: level name or int value, defaults to DEBUG
- *   - [bubble]: bool, defaults to true
+ * - publisher: (one of the following configurations)
+ *   # Option 1: Service-based configuration
+ *   - id: string, service id of a publisher implementation
+ *
+ *   # Option 2: Direct connection configuration
+ *   - hostname: string, server hostname
+ *   - [port]: int, server port (default: 12201)
+ *   - [chunk_size]: int, UDP packet size (default: 1420)
+ *   - [encoder]: string, encoding format ('json' or 'compressed_json')
+ * - [level]: level name or int value, defaults to DEBUG
+ * - [bubble]: bool, defaults to true
  *
  * - chromephp:
  *   - [level]: level name or int value, defaults to DEBUG

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -52,17 +52,17 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *
  * - gelf:
- * - publisher: (one of the following configurations)
- *   # Option 1: Service-based configuration
- *   - id: string, service id of a publisher implementation
+ *   - publisher: (one of the following configurations)
+ *     # Option 1: Service-based configuration
+ *     - id: string, service id of a publisher implementation
  *
- *   # Option 2: Direct connection configuration
- *   - hostname: string, server hostname
- *   - [port]: int, server port (default: 12201)
- *   - [chunk_size]: int, UDP packet size (default: 1420)
- *   - [encoder]: string, encoding format ('json' or 'compressed_json')
- * - [level]: level name or int value, defaults to DEBUG
- * - [bubble]: bool, defaults to true
+ *     # Option 2: Direct connection configuration
+ *     - hostname: string, server hostname
+ *     - [port]: int, server port (default: 12201)
+ *     - [chunk_size]: int, UDP packet size (default: 1420)
+ *     - [encoder]: string, encoding format ('json' or 'compressed_json')
+ *   - [level]: level name or int value, defaults to DEBUG
+ *   - [bubble]: bool, defaults to true
  *
  * - chromephp:
  *   - [level]: level name or int value, defaults to DEBUG

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *
  * - gelf:
- *   - publiser:
+ *   - publisher:
  *      - id: string, service id of a publisher implementation, optional if hostname is given
  *      - hostname: string, optional if id is given
  *      - [port]: int, defaults to 12201

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -23,6 +23,7 @@ use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Bridge\Monolog\Processor\WebProcessor;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -221,10 +222,28 @@ class MonologExtension extends Extension
                     ]);
                     $transport->setPublic(false);
 
+                    if (isset($handler['publisher']['encoder'])) {
+                        if ('compressed_json' === $handler['publisher']['encoder']) {
+                            $encoderClass = 'Gelf\Encoder\CompressedJsonEncoder';
+                        } elseif ('json' === $handler['publisher']['encoder']) {
+                            $encoderClass = 'Gelf\Encoder\JsonEncoder';
+                        } else {
+                            throw new InvalidConfigurationException('The gelf message encoder must be either "compressed_json" or "json".');
+                        }
+
+                        $encoder = new Definition($encoderClass);
+                        $encoder->setPublic(false);
+
+                        $transport->addMethodCall('setMessageEncoder', [$encoder]);
+                    }
+
                     $publisher = new Definition('Gelf\Publisher', []);
                     $publisher->addMethodCall('addTransport', [$transport]);
                     $publisher->setPublic(false);
                 } elseif (class_exists('Gelf\MessagePublisher')) {
+                    if (isset($handler['publisher']['encoder']) && 'compressed_json' !== $handler['publisher']['encoder']) {
+                        throw new InvalidConfigurationException('The Gelf\MessagePublisher publisher supports only the compressed json encoding. Omit the option to use the default encoding or use "compressed_json" as the encoder option.');
+                    }
                     $publisher = new Definition('Gelf\MessagePublisher', [
                         $handler['publisher']['hostname'],
                         $handler['publisher']['port'],

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -228,7 +228,7 @@ class MonologExtension extends Extension
                         } elseif ('json' === $handler['publisher']['encoder']) {
                             $encoderClass = 'Gelf\Encoder\JsonEncoder';
                         } else {
-                            throw new InvalidConfigurationException('The gelf message encoder must be either "compressed_json" or "json".');
+                            throw new \RuntimeException('The gelf message encoder must be either "compressed_json" or "json".');
                         }
 
                         $encoder = new Definition($encoderClass);

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -242,7 +242,7 @@ class MonologExtension extends Extension
                     $publisher->setPublic(false);
                 } elseif (class_exists('Gelf\MessagePublisher')) {
                     if (isset($handler['publisher']['encoder']) && 'compressed_json' !== $handler['publisher']['encoder']) {
-                        throw new InvalidConfigurationException('The Gelf\MessagePublisher publisher supports only the compressed json encoding. Omit the option to use the default encoding or use "compressed_json" as the encoder option.');
+                        throw new \RuntimeException('The Gelf\MessagePublisher publisher supports only the compressed json encoding. Omit the option to use the default encoding or use "compressed_json" as the encoder option.');
                     }
                     $publisher = new Definition('Gelf\MessagePublisher', [
                         $handler['publisher']['hostname'],

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -23,7 +23,6 @@ use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Bridge\Monolog\Processor\WebProcessor;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -111,6 +111,28 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('gelf.publisher', $config['handlers']['gelf']['publisher']['id']);
     }
 
+    public function testGelfPublisherWithEncoder(): void
+    {
+        $configs = [
+            [
+                'handlers' => [
+                    'gelf' => [
+                        'type' => 'gelf',
+                        'publisher' => [
+                            'hostname' => 'localhost',
+                            'encoder' => 'compressed_json',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $config = $this->process($configs);
+
+        $this->assertEquals('localhost', $config['handlers']['gelf']['publisher']['hostname']);
+        $this->assertEquals('compressed_json', $config['handlers']['gelf']['publisher']['encoder']);
+    }
+
     public function testArrays()
     {
         $configs = [

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -111,7 +111,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('gelf.publisher', $config['handlers']['gelf']['publisher']['id']);
     }
 
-    public function testGelfPublisherWithEncoder(): void
+    public function testGelfPublisherWithEncoder()
     {
         $configs = [
             [

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -23,7 +23,6 @@ use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessor;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessorWithPriority;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\RedeclareMethodProcessor;
-use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\DummyClassForClassExistsCheck;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\ServiceWithChannel;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -188,97 +187,6 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->expectException(InvalidConfigurationException::class);
 
         $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => []]]]], $container);
-    }
-
-    public function testExceptionWhenUsingLegacyGelfImplementationWithUnsupportedEncoder(): void
-    {
-        if (!class_exists('Gelf\MessagePublisher')) {
-            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\MessagePublisher');
-        }
-
-        $container = new ContainerBuilder();
-        $loader = new MonologExtension();
-
-        $this->expectException(InvalidConfigurationException::class);
-
-        $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => 'json']]]]], $container);
-    }
-
-    /**
-     * @dataProvider encoderOptionsProvider
-     */
-    public function testLegacyGelfImplementationEncoderOption(array $config): void
-    {
-        if (!class_exists('Gelf\MessagePublisher')) {
-            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\MessagePublisher');
-        }
-
-        $container = $this->getContainer($config);
-        $this->assertTrue($container->hasDefinition('monolog.handler.gelf'));
-
-        $handler = $container->getDefinition('monolog.handler.gelf');
-        /** @var Definition $publisher */
-        $publisher = $handler->getArguments()[0];
-
-        $this->assertDICConstructorArguments($publisher, ['localhost', 12201, 1420]);
-    }
-
-    public function encoderOptionsProvider(): array
-    {
-        return [
-            [
-                [['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => 'compressed_json']]]]],
-            ],
-            [
-                [['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost']]]]],
-            ],
-        ];
-    }
-
-    public function testExceptionWhenUsingGelfWithInvalidEncoder(): void
-    {
-        if (!class_exists('Gelf\Transport\UdpTransport')) {
-            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\Transport\UdpTransport');
-        }
-
-        $container = new ContainerBuilder();
-        $loader = new MonologExtension();
-
-        $this->expectException(InvalidConfigurationException::class);
-
-        $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => 'invalid_encoder']]]]], $container);
-    }
-
-    /**
-     * @dataProvider gelfEncoderProvider
-     */
-    public function testGelfWithEncoder($encoderValue, $expectedClass): void
-    {
-        if (!class_exists('Gelf\Transport\UdpTransport')) {
-            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\Transport\UdpTransport');
-        }
-
-        $container = $this->getContainer([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => $encoderValue]]]]]);
-        $this->assertTrue($container->hasDefinition('monolog.handler.gelf'));
-
-        $handler = $container->getDefinition('monolog.handler.gelf');
-        /** @var Definition $publisher */
-        $publisher = $handler->getArguments()[0];
-        /** @var Definition $transport */
-        $transport = $publisher->getMethodCalls()[0][1][0];
-        $encoder = $transport->getMethodCalls()[0][1][0];
-
-        $this->assertDICConstructorArguments($transport, ['localhost', 12201, 1420]);
-        $this->assertDICDefinitionClass($encoder, $expectedClass);
-        $this->assertDICConstructorArguments($handler, [$publisher, 'DEBUG', true]);
-    }
-
-    public function gelfEncoderProvider(): array
-    {
-        return [
-            ['json', 'Gelf\Encoder\JsonEncoder'],
-            ['compressed_json', 'Gelf\Encoder\CompressedJsonEncoder'],
-        ];
     }
 
     public function testExceptionWhenUsingServiceWithoutId()

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -189,6 +189,97 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => []]]]], $container);
     }
 
+    public function testExceptionWhenUsingLegacyGelfImplementationWithUnsupportedEncoder(): void
+    {
+        if (!class_exists('Gelf\MessagePublisher')) {
+            class_alias(\stdClass::class, 'Gelf\MessagePublisher');
+        }
+
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => 'json']]]]], $container);
+    }
+
+    /**
+     * @dataProvider encoderOptionsProvider
+     */
+    public function testLegacyGelfImplementationEncoderOption(array $config): void
+    {
+        if (!class_exists('Gelf\MessagePublisher')) {
+            class_alias(\stdClass::class, 'Gelf\MessagePublisher');
+        }
+
+        $container = $this->getContainer($config);
+        $this->assertTrue($container->hasDefinition('monolog.handler.gelf'));
+
+        $handler = $container->getDefinition('monolog.handler.gelf');
+        /** @var Definition $publisher */
+        $publisher = $handler->getArguments()[0];
+
+        $this->assertDICConstructorArguments($publisher, ['localhost', 12201, 1420]);
+    }
+
+    public function encoderOptionsProvider(): array
+    {
+        return [
+            [
+                [['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => 'compressed_json']]]]],
+            ],
+            [
+                [['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost']]]]],
+            ],
+        ];
+    }
+
+    public function testExceptionWhenUsingGelfWithInvalidEncoder(): void
+    {
+        if (!class_exists('Gelf\Transport\UdpTransport')) {
+            class_alias(\stdClass::class, 'Gelf\Transport\UdpTransport');
+        }
+
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => 'invalid_encoder']]]]], $container);
+    }
+
+    /**
+     * @dataProvider gelfEncoderProvider
+     */
+    public function testGelfWithEncoder($encoderValue, $expectedClass): void
+    {
+        if (!class_exists('Gelf\Transport\UdpTransport')) {
+            class_alias(\stdClass::class, 'Gelf\Transport\UdpTransport');
+        }
+
+        $container = $this->getContainer([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => $encoderValue]]]]]);
+        $this->assertTrue($container->hasDefinition('monolog.handler.gelf'));
+
+        $handler = $container->getDefinition('monolog.handler.gelf');
+        /** @var Definition $publisher */
+        $publisher = $handler->getArguments()[0];
+        /** @var Definition $transport */
+        $transport = $publisher->getMethodCalls()[0][1][0];
+        $encoder = $transport->getMethodCalls()[0][1][0];
+
+        $this->assertDICConstructorArguments($transport, ['localhost', 12201, 1420]);
+        $this->assertDICDefinitionClass($encoder, $expectedClass);
+        $this->assertDICConstructorArguments($handler, [$publisher, 'DEBUG', true]);
+    }
+
+    public function gelfEncoderProvider(): array
+    {
+        return [
+            ['json', 'Gelf\Encoder\JsonEncoder'],
+            ['compressed_json', 'Gelf\Encoder\CompressedJsonEncoder'],
+        ];
+    }
+
     public function testExceptionWhenUsingServiceWithoutId()
     {
         $container = new ContainerBuilder();

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessor;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessorWithPriority;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\RedeclareMethodProcessor;
+use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\DummyClassForClassExistsCheck;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\ServiceWithChannel;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -192,7 +193,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     public function testExceptionWhenUsingLegacyGelfImplementationWithUnsupportedEncoder(): void
     {
         if (!class_exists('Gelf\MessagePublisher')) {
-            class_alias(\stdClass::class, 'Gelf\MessagePublisher');
+            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\MessagePublisher');
         }
 
         $container = new ContainerBuilder();
@@ -209,7 +210,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     public function testLegacyGelfImplementationEncoderOption(array $config): void
     {
         if (!class_exists('Gelf\MessagePublisher')) {
-            class_alias(\stdClass::class, 'Gelf\MessagePublisher');
+            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\MessagePublisher');
         }
 
         $container = $this->getContainer($config);
@@ -237,7 +238,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     public function testExceptionWhenUsingGelfWithInvalidEncoder(): void
     {
         if (!class_exists('Gelf\Transport\UdpTransport')) {
-            class_alias(\stdClass::class, 'Gelf\Transport\UdpTransport');
+            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\Transport\UdpTransport');
         }
 
         $container = new ContainerBuilder();
@@ -254,7 +255,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     public function testGelfWithEncoder($encoderValue, $expectedClass): void
     {
         if (!class_exists('Gelf\Transport\UdpTransport')) {
-            class_alias(\stdClass::class, 'Gelf\Transport\UdpTransport');
+            class_alias(DummyClassForClassExistsCheck::class, 'Gelf\Transport\UdpTransport');
         }
 
         $container = $this->getContainer([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => ['hostname' => 'localhost', 'encoder' => $encoderValue]]]]]);


### PR DESCRIPTION
This commit introduces the ability to specify custom encoders (`json` and `compressed_json`) for Gelf publishers in Monolog's configuration.

Overview
This PR introduces an enhancement to the Symfony Monolog Bundle by adding a configuration option for setting the message encoder for the GELF handler's publisher. This change addresses a backward compatibility issue introduced in the 2.0 update of the graylog2/gelf-php package, which shifted the default message encoder from CompressedJsonEncoder to JsonEncoder. Thus an upgrade silently breakes the logging.

https://github.com/bzikarsky/gelf-php/commit/f2625cf008289e9a5004bf55eaf6e95dcbcbc6c0#diff-9520be6ea98f5ded11cbe62c500f1a8fef819810d8836d2b15189cdbc073900cR32
https://github.com/bzikarsky/gelf-php/commit/f2625cf008289e9a5004bf55eaf6e95dcbcbc6c0#diff-72a9d13c23b7d615833219f0dfc92be317d9a4981de7b4747e287db62aaa1079L69

In a Symfony project, to override this default behavior, users had to manually construct and define the transport, publisher, and encoder as a service and then use it in the Monolog configuration. This approach, while functional, is cumbersome. It would be more user-friendly to enable setting the encoder via a simple configuration option. The proposed change would be:

```
            gelf:
                type: gelf
                level: debug
                publisher:
                    hostname: '%env(resolve:LOGSTASH_HOSTNAME)%'
                    port: '%env(resolve:LOGSTASH_PORT)%'
                    encoder: compressed_json  # Optional: 'json' or 'compressed_json'
```
This new encoder configuration is optional and does not have an explicit default value, thereby preserving the existing behavior (albeit the recent default may not align with prior expectations).

While it might be tempting to expose more variability (like using class names or service IDs directly), overly customizable options may not add practical value and could complicate the configuration unnecessarily, 'coz YAGNI :)