### PR TITLE
[CI] Bump github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
-
                 with:
                     php-version: 8.3
                     coverage: none
@@ -44,9 +43,10 @@ jobs:
                     -   php: '8.4'
                         deps: highest
                         monolog: '3.*'
+
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -64,7 +64,7 @@ jobs:
                 run: composer require --no-update monolog/monolog:${{ matrix.monolog }}
 
             -   name: Composer install
-                uses: ramsey/composer-install@v1
+                uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: '${{ matrix.deps }}'
 


### PR DESCRIPTION
Fixes the `ramsey/composer-install` cache feature and warnings:
- The `set-output` command is deprecated and will be disabled soon.
- The `save-state` command is deprecated and will be disabled soon.