### PR TITLE
Add support for Symfony 8

### DIFF
--- a/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AddProcessorsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('monolog.logger')) {
             return;

--- a/DependencyInjection/Compiler/AddSwiftMailerTransportPass.php
+++ b/DependencyInjection/Compiler/AddSwiftMailerTransportPass.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AddSwiftMailerTransportPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $handlers = $container->getParameter('monolog.swift_mailer.handlers');
 

--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -36,7 +36,7 @@ class DebugHandlerPass implements CompilerPassInterface
         $this->channelPass = $channelPass;
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('profiler')) {
             return;

--- a/DependencyInjection/Compiler/FixEmptyLoggerPass.php
+++ b/DependencyInjection/Compiler/FixEmptyLoggerPass.php
@@ -40,7 +40,7 @@ class FixEmptyLoggerPass implements CompilerPassInterface
         $this->channelPass = $channelPass;
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container->register('monolog.handler.null_internal', 'Monolog\Handler\NullHandler');
         foreach ($this->channelPass->getChannels() as $channel) {

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -30,7 +30,7 @@ class LoggerChannelPass implements CompilerPassInterface
 {
     protected $channels = ['app'];
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('monolog.logger')) {
             return;

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -55,7 +55,7 @@ class MonologExtension extends Extension
      * @param array            $configs   An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
@@ -144,15 +144,13 @@ class MonologExtension extends Extension
 
     /**
      * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
      */
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): string
     {
         return __DIR__.'/../Resources/config/schema';
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://symfony.com/schema/dic/monolog';
     }

--- a/MonologBundle.php
+++ b/MonologBundle.php
@@ -31,7 +31,7 @@ class MonologBundle extends Bundle
     /**
      * @return void
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/config": "^5.4 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^7.1"
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/phpunit-bridge": "^7.1 || ^8.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MonologBundle\\": "" },


### PR DESCRIPTION
Add support of Symfony 8 and fixes typehint errors like 
```
Compile Error: Declaration of Symfony\Bundle\MonologBundle\MonologBundle::build(Symfony\Component\DependencyInjection\ContainerBuilder $container) must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::build(Symfony\Component\DependencyInjection\ContainerBuilder $container): void
```