### PR TITLE
Run the tests with PHPUnit 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
                     -   php: '8.2'
                         deps: lowest
                         symfony: '7.3.*'
-                        deprecations: max[self]=0
                     -   php: '8.4'
                         deps: highest
                         symfony: '7.4.*'
@@ -62,10 +61,5 @@ jobs:
                 with:
                     dependency-versions: '${{ matrix.deps }}'
 
-            -   name: Install PHPUnit dependencies
-                run: vendor/bin/simple-phpunit install
-
             -   name: Run tests
-                run: vendor/bin/simple-phpunit -v --coverage-text
-                env:
-                    SYMFONY_DEPRECATIONS_HELPER: '${{ matrix.deprecations }}'
+                run: vendor/bin/phpunit --coverage-text

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ vendor
 composer.phar
 composer.lock
 phpunit.xml
-.phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "symfony/monolog-bridge": "^7.3"
     },
     "require-dev": {
+        "phpunit/phpunit": "^11.5.41",
         "symfony/console": "^7.3",
-        "symfony/phpunit-bridge": "^7.3",
         "symfony/yaml": "^7.3"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         shortenArraysForExportThreshold="10"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnNotice="true"
+>
     <testsuites>
         <testsuite name="MonologBundle for the Symfony Framework">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+
+    <source ignoreSuppressionOfDeprecations="true" restrictNotices="true" restrictWarnings="true">
         <include>
             <directory>./src/</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use Composer\InstalledVersions;
 use Monolog\Logger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -50,10 +52,8 @@ class ConfigurationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideProcessStringChannels
-     */
-    public function testProcessStringChannels($string, $expectedString, $isInclusive)
+    #[DataProvider('provideProcessStringChannels')]
+    public function testProcessStringChannels(string $string, string $expectedString, bool $isInclusive)
     {
         $configs = [
             [
@@ -88,10 +88,8 @@ class ConfigurationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideGelfPublisher
-     */
-    public function testGelfPublisherService($publisher)
+    #[DataProvider('provideGelfPublisher')]
+    public function testGelfPublisherService(mixed $publisher)
     {
         $configs = [
             [
@@ -398,9 +396,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('monolog_redis_test', $config['handlers']['redis']['redis']['key_name']);
     }
 
-    /**
-     * @group legacy
-     */
+    #[IgnoreDeprecations]
     public function testConsoleFormatterOptionsRename()
     {
         $configs = [
@@ -480,9 +476,7 @@ class ConfigurationTest extends TestCase
         $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['both2']);
     }
 
-    /**
-     * @dataProvider processPsr3MessagesProvider
-     */
+    #[DataProvider('processPsr3MessagesProvider')]
     public function testWithProcessPsr3Messages(array $configuration, array $processedConfiguration): void
     {
         $configs = [
@@ -528,7 +522,7 @@ class ConfigurationTest extends TestCase
      *
      * @return array A normalized array
      */
-    protected function process($configs)
+    private function process(array $configs): array
     {
         $processor = new Processor();
 

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Handler\RollbarHandler;
 use Monolog\Processor\UidProcessor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessorWithPriority;
@@ -466,7 +468,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTag', ['foo,bar']);
     }
 
-    /** @group legacy */
+    #[IgnoreDeprecations]
     public function testFingersCrossedHandlerWhenExcluded404sAreSpecified()
     {
         $activation = new Definition(ErrorLevelActivationStrategy::class, ['WARNING']);
@@ -532,9 +534,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null]);
     }
 
-    /**
-     * @dataProvider v2RemovedDataProvider
-     */
+    #[DataProvider('v2RemovedDataProvider')]
     public function testV2Removed(string $type)
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -555,9 +555,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideLoglevelParameterConfig
-     */
+    #[DataProvider('provideLoglevelParameterConfig')]
     public function testLogLevelfromParameter(array $parameters, array $config, $expectedClass, array $expectedArgs)
     {
         $container = new ContainerBuilder();
@@ -652,9 +650,6 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertEquals('reset', $tags['kernel.reset'][0]['method']);
     }
 
-    /**
-     * @requires PHP 8.0
-     */
     public function testAsMonologProcessorAutoconfigurationRedeclareMethod(): void
     {
         $this->expectException(\LogicException::class);
@@ -665,9 +660,6 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ]);
     }
 
-    /**
-     * @requires PHP 8.0
-     */
     public function testAsMonologProcessorAutoconfigurationWithPriority(): void
     {
         $container = $this->getContainer([], [
@@ -690,9 +682,6 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ], $container->getDefinition(FooProcessorWithPriority::class)->getTag('monolog.processor'));
     }
 
-    /**
-     * @requires PHP 8.0
-     */
     public function testWithLoggerChannelAutoconfiguration(): void
     {
         $container = $this->getContainer([], [
@@ -706,7 +695,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ], $container->getDefinition(ServiceWithChannel::class)->getTag('monolog.logger'));
     }
 
-    protected function getContainer(array $config = [], array $thirdPartyDefinitions = []): ContainerBuilder
+    private function getContainer(array $config = [], array $thirdPartyDefinitions = []): ContainerBuilder
     {
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag());
         foreach ($thirdPartyDefinitions as $id => $definition) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Let's run our test suite with the most recent PHPUnit version that we can use on PHP 8.2.