### PR TITLE
Add Fabbot as a GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,23 +5,6 @@ on:
     pull_request:
 
 jobs:
-    php-cs-fixer:
-        runs-on: ubuntu-latest
-        name: Coding Standards
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v4
-
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: 8.3
-                    coverage: none
-                    tools: php-cs-fixer, cs2pr
-
-            -   name: Run PHP-CS-Fixer
-                run: php-cs-fixer fix --dry-run --format checkstyle | cs2pr
-
     test:
         runs-on: ubuntu-latest
         name: PHPUnit Tests

--- a/.github/workflows/fabbot.yaml
+++ b/.github/workflows/fabbot.yaml
@@ -1,0 +1,15 @@
+name: Fabbot
+
+on:
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    call-fabbot:
+        name: Fabbot
+        uses: symfony-tools/fabbot/.github/workflows/fabbot.yml@main
+        with:
+            package: Monolog Bundle
+            check_license: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Uses [symfony-tools/fabbot](https://github.com/symfony-tools/fabbot).
This workflow runs PHP-CS-Fixer, so we can remove it from the "ci" workflow.
