### PR TITLE
Don't use deprecated Monolog consts

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
 use Composer\InstalledVersions;
+use Monolog\Level;
 use Monolog\Logger;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -545,7 +546,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('connection_string')->end() // socket_handler
                 ->scalarNode('timeout')->end() // socket_handler, logentries, pushover & slack
                 ->scalarNode('time')->defaultValue(60)->end() // deduplication
-                ->scalarNode('deduplication_level')->defaultValue(Logger::ERROR)->end() // deduplication
+                ->scalarNode('deduplication_level')->defaultValue(Level::Error->value)->end() // deduplication
                 ->scalarNode('store')->defaultNull()->end() // deduplication
                 ->scalarNode('connection_timeout')->end() // socket_handler, logentries, pushover & slack
                 ->booleanNode('persistent')->end() // socket_handler

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use Composer\InstalledVersions;
-use Monolog\Logger;
+use Monolog\Level;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
@@ -254,11 +254,11 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame('console', $config['handlers']['console']['type']);
         $this->assertSame([
-            OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
-            OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
+            OutputInterface::VERBOSITY_NORMAL => Level::Notice->value,
+            OutputInterface::VERBOSITY_VERBOSE => Level::Info->value,
             OutputInterface::VERBOSITY_VERY_VERBOSE => 200,
-            OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
-            OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
+            OutputInterface::VERBOSITY_QUIET => Level::Error->value,
+            OutputInterface::VERBOSITY_DEBUG => Level::Debug->value,
         ], $config['handlers']['console']['verbosity_levels']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Monolog `Logger::<level>` constants are deprecated. Since 4.x supports only Monolog >= 3.5, the `Level` enum can be used instead. 