### PR TITLE
Require Symfony 6.4 and PHP 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,28 +13,19 @@ jobs:
             matrix:
                 php: [ '8.1', '8.2', '8.3', '8.4' ]
                 monolog: [ '2.*' ]
-                symfony: [ '6.4.*' ]
+                symfony: [ false ]
                 include:
-                    -   php: '7.2'
-                        symfony: '5.4.*'
-                        monolog: '1.*'
-                    -   php: '7.4'
+                    -   php: '8.1'
                         deps: lowest
-                        symfony: '5.4.*'
+                        symfony: '6.4.*'
+                        monolog: '1.*'
                         deprecations: max[self]=0
                     -   php: '8.1'
                         monolog: '3.*'
                         symfony: '6.4.*'
-                    -   php: '8.2'
-                        monolog: '3.*'
-                        symfony: '7.3.*'
-                    -   php: '8.3'
-                        monolog: '3.*'
-                        symfony: '7.3.*'
                     -   php: '8.4'
                         deps: highest
                         monolog: '3.*'
-                        symfony: '7.4.*'
 
         env:
             SYMFONY_REQUIRE: ${{ matrix.symfony }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Add `slack.exclude_fields` and `slackwebhook.exclude_fields` configuration
 * Add a processor to all loggers only when tags do not specify a channel or handler
 * Deprecate abstract `monolog.activation_strategy.not_found` and `monolog.handler.fingers_crossed.error_level_activation_strategy` service definitions
+* Drop support for PHP < 8.1
+* Drop support for Symfony < 6.4
 
 ## 3.10.0 (2023-11-06)
 

--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,19 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "composer-runtime-api": "^2.0",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
-        "symfony/config": "^5.4 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-        "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/http-kernel": "^6.4 || ^7.0",
+        "symfony/monolog-bridge": "^6.4 || ^7.0",
         "symfony/polyfill-php84": "^1.30"
     },
     "require-dev": {
-        "symfony/console": "^5.4 || ^6.0 || ^7.0",
+        "symfony/console": "^6.4 || ^7.0",
         "symfony/phpunit-bridge": "^7.1",
-        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
+        "symfony/yaml": "^6.4 || ^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MonologBundle\\": "src" }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix https://github.com/symfony/monolog-bundle/pull/519#discussion_r2375617993
| License       | MIT

Bumping Symfony to 6.4 also means bumping PHP to 8.1, as that's the min version supported by that Symfony version.