### PR TITLE
Add `TelegramBotHandler` topics support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Deprecate abstract `monolog.activation_strategy.not_found` and `monolog.handler.fingers_crossed.error_level_activation_strategy` service definitions
 * Drop support for PHP < 8.1
 * Drop support for Symfony < 6.4
+* Add TelegramBotHandler `topic` support
 
 ## 3.10.0 (2023-11-06)
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -368,6 +368,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [disable_notification]: bool, defaults to false, sends the message silently. Users will receive a notification with no sound
  *   - [split_long_messages]: bool, defaults to false, split messages longer than 4096 bytes into multiple messages
  *   - [delay_between_messages]: bool, defaults to false, adds a 1sec delay/sleep between sending split messages
+ *   - [topic]: optional the unique identifier for the target message thread (topic) of the forum; for forum supergroups only
  *
  * - sampling:
  *   - handler: the wrapped handler's name
@@ -603,6 +604,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('disable_notification')->defaultNull()->end() // telegram
                 ->booleanNode('split_long_messages')->defaultFalse()->end() // telegram
                 ->booleanNode('delay_between_messages')->defaultFalse()->end() // telegram
+                ->integerNode('topic')->defaultNull()->end() // telegram
                 ->integerNode('factor')->defaultValue(1)->min(1)->end() // sampling
                 ->arrayNode('tags') // loggly
                     ->beforeNormalization()

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -343,6 +343,7 @@ class MonologExtension extends Extension
                     $handler['disable_notification'],
                     $handler['split_long_messages'],
                     $handler['delay_between_messages'],
+                    $handler['topic'],
                 ]);
                 break;
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -258,6 +258,7 @@ class ConfigurationTest extends TestCase
                         'type' => 'telegram',
                         'token' => 'bot-token',
                         'channel' => '-100',
+                        'topic' => 1234,
                     ],
                 ],
             ],
@@ -267,6 +268,7 @@ class ConfigurationTest extends TestCase
 
         $this->assertEquals('bot-token', $config['handlers']['telegram']['token']);
         $this->assertEquals('-100', $config['handlers']['telegram']['channel']);
+        $this->assertEquals(1234, $config['handlers']['telegram']['topic']);
     }
 
     public function testWithConsoleHandler()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR adds support for the `topic` option in `TelegramBotHandler`, enabling the use of the Telegram message thread ID (`message_thread_id`). This unique identifier targets specific message threads (topics) within forum supergroups.

**Reference:**
- https://github.com/Seldaek/monolog/pull/1802
- [How to get the `message_thread_id`](https://stackoverflow.com/a/75178418)
- https://github.com/symfony/monolog-bundle/pull/484
