### PR TITLE
Remove incomplete service definitions

### DIFF
--- a/CHANGELOG-4.md
+++ b/CHANGELOG-4.md
@@ -5,3 +5,4 @@
 * Drop support for PHP < 8.2
 * Drop support for Symfony < 7.3
 * Drop support for Monolog < 3.5
+* Remove abstract `monolog.activation_strategy.not_found` and `monolog.handler.fingers_crossed.error_level_activation_strategy` service definitions

--- a/config/monolog.php
+++ b/config/monolog.php
@@ -21,10 +21,8 @@ use Monolog\Formatter\LogstashFormatter;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Formatter\ScalarFormatter;
 use Monolog\Formatter\WildfireFormatter;
-use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
-use Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -42,11 +40,6 @@ return static function (ContainerConfigurator $container) {
         ->set('monolog.logger_prototype', Logger::class)
             ->args([abstract_arg('channel')])
             ->abstract()
-
-        ->set('monolog.activation_strategy.not_found', NotFoundActivationStrategy::class)->abstract()
-            ->deprecate('symfony/monolog-bundle', '3.11', 'The "%service_id%" service is deprecated.')
-        ->set('monolog.handler.fingers_crossed.error_level_activation_strategy', ErrorLevelActivationStrategy::class)->abstract()
-            ->deprecate('symfony/monolog-bundle', '3.11', 'The "%service_id%" service is deprecated.')
 
         // Formatters
         ->set('monolog.formatter.chrome_php', ChromePHPFormatter::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Inspired by https://github.com/symfony/monolog-bundle/pull/207#issuecomment-285097790.
These service definitions are unused and, to my understanding, were only kept for BC reasons. Maybe it's time to remove them?