### PR TITLE
Remove return `void` from test methods

### DIFF
--- a/tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
@@ -111,7 +111,7 @@ class AddProcessorsPassTest extends TestCase
         ];
     }
 
-    protected function getContainer()
+    protected function getContainer(): ContainerBuilder
     {
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../config'));

--- a/tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -144,7 +144,7 @@ class LoggerChannelPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    private function getContainer()
+    private function getContainer(): ContainerBuilder
     {
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../config'));
@@ -186,7 +186,7 @@ class LoggerChannelPassTest extends TestCase
         return $container;
     }
 
-    private function getContainerWithSetter()
+    private function getContainerWithSetter(): ContainerBuilder
     {
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../config'));
@@ -212,10 +212,7 @@ class LoggerChannelPassTest extends TestCase
         return $container;
     }
 
-    /**
-     * @return ContainerBuilder
-     */
-    private function getFunctionalContainer()
+    private function getFunctionalContainer(): ContainerBuilder
     {
         $container = new ContainerBuilder();
         $container->setParameter('monolog.additional_channels', []);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -158,7 +158,7 @@ class ConfigurationTest extends TestCase
 
         $this->expectException(InvalidConfigurationException::class);
 
-        $config = $this->process($configs);
+        $this->process($configs);
     }
 
     public function testMergingInvalidChannels()
@@ -184,7 +184,7 @@ class ConfigurationTest extends TestCase
 
         $this->expectException(InvalidConfigurationException::class);
 
-        $config = $this->process($configs);
+        $this->process($configs);
     }
 
     public function testWithElasticsearchHandler()
@@ -396,7 +396,7 @@ class ConfigurationTest extends TestCase
     }
 
     #[DataProvider('processPsr3MessagesProvider')]
-    public function testWithProcessPsr3Messages(array $configuration, array $processedConfiguration): void
+    public function testWithProcessPsr3Messages(array $configuration, array $processedConfiguration)
     {
         $configs = [
             [

--- a/tests/DependencyInjection/DependencyInjectionTestCase.php
+++ b/tests/DependencyInjection/DependencyInjectionTestCase.php
@@ -12,26 +12,24 @@
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Definition;
 
 abstract class DependencyInjectionTestCase extends TestCase
 {
     /**
      * Assertion on the Class of a DIC Service Definition.
-     *
-     * @param \Symfony\Component\DependencyInjection\Definition $definition
-     * @param string                                            $expectedClass
      */
-    protected function assertDICDefinitionClass($definition, $expectedClass)
+    protected function assertDICDefinitionClass(Definition $definition, string $expectedClass)
     {
         $this->assertEquals($expectedClass, $definition->getClass(), 'Expected Class of the DIC Container Service Definition is wrong.');
     }
 
-    protected function assertDICConstructorArguments($definition, $args)
+    protected function assertDICConstructorArguments(Definition $definition, array $args)
     {
         $this->assertEquals($args, $definition->getArguments(), "Expected and actual DIC Service constructor arguments of definition '".$definition->getClass()."' don't match.");
     }
 
-    protected function assertDICDefinitionMethodCallAt($pos, $definition, $methodName, ?array $params = null)
+    protected function assertDICDefinitionMethodCallAt(int $pos, Definition $definition, string $methodName, ?array $params = null)
     {
         $calls = $definition->getMethodCalls();
         if (isset($calls[$pos][0])) {

--- a/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
+++ b/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
@@ -207,7 +207,7 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertNotContainsEquals(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should not be enabled');
     }
 
-    public function testPsrLogMessageProcessorHasConstructorArguments(): void
+    public function testPsrLogMessageProcessorHasConstructorArguments()
     {
         $container = $this->getContainer('process_psr_3_messages_with_arguments');
 
@@ -240,7 +240,7 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertSame(['addHeader', [['Foo: bar', 'Baz: inga']]], $methodCalls[1]);
     }
 
-    protected function getContainer($fixture)
+    protected function getContainer($fixture): ContainerBuilder
     {
         $container = new ContainerBuilder();
         $container->registerExtension(new MonologExtension());
@@ -255,5 +255,5 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         return $container;
     }
 
-    abstract protected function loadFixture(ContainerBuilder $container, $fixture);
+    abstract protected function loadFixture(ContainerBuilder $container, string $fixture);
 }

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -507,7 +507,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     }
 
     #[DataProvider('provideLoglevelParameterConfig')]
-    public function testLogLevelfromParameter(array $parameters, array $config, $expectedClass, array $expectedArgs)
+    public function testLogLevelfromParameter(array $parameters, array $config, string $expectedClass, array $expectedArgs)
     {
         $container = new ContainerBuilder();
         foreach ($parameters as $name => $value) {
@@ -601,7 +601,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertEquals('reset', $tags['kernel.reset'][0]['method']);
     }
 
-    public function testAsMonologProcessorAutoconfigurationRedeclareMethod(): void
+    public function testAsMonologProcessorAutoconfigurationRedeclareMethod()
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('AsMonologProcessor attribute cannot declare a method on "Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\RedeclareMethodProcessor::__invoke()".');
@@ -611,7 +611,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ]);
     }
 
-    public function testAsMonologProcessorAutoconfigurationWithPriority(): void
+    public function testAsMonologProcessorAutoconfigurationWithPriority()
     {
         $container = $this->getContainer([], [
             FooProcessorWithPriority::class => (new Definition(FooProcessorWithPriority::class))->setAutoconfigured(true),
@@ -633,7 +633,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ], $container->getDefinition(FooProcessorWithPriority::class)->getTag('monolog.processor'));
     }
 
-    public function testWithLoggerChannelAutoconfiguration(): void
+    public function testWithLoggerChannelAutoconfiguration()
     {
         $container = $this->getContainer([], [
             ServiceWithChannel::class => (new Definition(ServiceWithChannel::class))->setAutoconfigured(true),

--- a/tests/DependencyInjection/XmlMonologExtensionTest.php
+++ b/tests/DependencyInjection/XmlMonologExtensionTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlMonologExtensionTest extends FixtureMonologExtensionTestCase
 {
-    protected function loadFixture(ContainerBuilder $container, $fixture)
+    protected function loadFixture(ContainerBuilder $container, string $fixture)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml'));
         $loader->load($fixture.'.xml');

--- a/tests/DependencyInjection/YamlMonologExtensionTest.php
+++ b/tests/DependencyInjection/YamlMonologExtensionTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class YamlMonologExtensionTest extends FixtureMonologExtensionTestCase
 {
-    protected function loadFixture(ContainerBuilder $container, $fixture)
+    protected function loadFixture(ContainerBuilder $container, string $fixture)
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
         $loader->load($fixture.'.yml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Noticed [Fabbot complaining about this](https://github.com/symfony/monolog-bundle/actions/runs/17984713264/job/51159772199). I also added some typehints.
