### PR TITLE
Deprecate `sentry` and `raven` handler types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Drop support for PHP < 8.1
 * Drop support for Symfony < 6.4
 * Add TelegramBotHandler `topic` support
+* Deprecate `sentry` and `raven` handler, use a `service` handler with [`sentry/sentry-symfony`](https://docs.sentry.io/platforms/php/guides/symfony/logs/) instead
 
 ## 3.10.0 (2023-11-06)
 
@@ -78,7 +79,7 @@
 
 ## 3.3.1 (2018-11-04)
 
-* Fixed compatiblity with Symfony 4.2
+* Fixed compatibility with Symfony 4.2
 
 ## 3.3.0 (2018-06-04)
 

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,14 @@
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/http-kernel": "^6.4 || ^7.0",
         "symfony/monolog-bridge": "^6.4 || ^7.0",
         "symfony/polyfill-php84": "^1.30"
     },
     "require-dev": {
         "symfony/console": "^6.4 || ^7.0",
-        "symfony/phpunit-bridge": "^7.1",
+        "symfony/phpunit-bridge": "^7.3.3",
         "symfony/yaml": "^6.4 || ^7.0"
     },
     "autoload": {

--- a/src/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/src/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -31,7 +31,7 @@ class DebugHandlerPass implements CompilerPassInterface
 
     public function __construct(LoggerChannelPass $channelPass)
     {
-        @trigger_error('The '.__CLASS__.' class is deprecated since version 2.12 and will be removed in 4.0. Use AddDebugLogProcessorPass in FrameworkBundle instead.', \E_USER_DEPRECATED);
+        trigger_deprecation('symfony/monolog-bundle', '2.12', 'The %s class is deprecated and will be removed in 4.0. Use AddDebugLogProcessorPass in FrameworkBundle instead.', __CLASS__);
 
         $this->channelPass = $channelPass;
     }

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -272,7 +272,7 @@ class MonologExtension extends Extension
                 break;
 
             case 'elasticsearch':
-                @trigger_error('The "elasticsearch" handler type is deprecated in MonologBundle since version 3.8.0, use the "elastica" type instead, or switch to the official Elastic client using the "elastic_search" type.', \E_USER_DEPRECATED);
+                trigger_deprecation('symfony/monolog-bundle', '3.8', 'The "elasticsearch" handler type is deprecated in MonologBundle since version 3.8.0, use the "elastica" type instead, or switch to the official Elastic client using the "elastic_search" type.');
                 // no break
 
             case 'elastica':
@@ -413,7 +413,7 @@ class MonologExtension extends Extension
                     $activation = new Reference($handler['activation_strategy']);
                 } elseif (!empty($handler['excluded_404s'])) {
                     if (class_exists(HttpCodeActivationStrategy::class)) {
-                        @trigger_error('The "excluded_404s" option is deprecated in MonologBundle since version 3.4.0, you should rely on the "excluded_http_codes" option instead.', \E_USER_DEPRECATED);
+                        trigger_deprecation('symfony/monolog-bundle', '3.4', 'The "excluded_404s" option is deprecated, you should rely on the "excluded_http_codes" option instead.');
                     }
                     $activationDef = new Definition('Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy', [
                         new Reference('request_stack'),
@@ -720,6 +720,7 @@ class MonologExtension extends Extension
                 break;
 
             case 'sentry':
+                trigger_deprecation('symfony/monolog-bundle', '3.11', 'The "sentry" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
                 if (null !== $handler['hub_id']) {
                     $hubId = $handler['hub_id'];
                 } else {
@@ -771,6 +772,7 @@ class MonologExtension extends Extension
                 break;
 
             case 'raven':
+                trigger_deprecation('symfony/monolog-bundle', '3.11', 'The "raven" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
                 if (null !== $handler['client_id']) {
                     $clientId = $handler['client_id'];
                 } else {

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -17,6 +17,7 @@ use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Handler\RollbarHandler;
 use Monolog\Logger;
 use Monolog\Processor\UidProcessor;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessor;
@@ -32,6 +33,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class MonologExtensionTest extends DependencyInjectionTestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function testLoadWithDefault()
     {
         $container = $this->getContainer([['handlers' => ['main' => ['type' => 'stream']]]]);
@@ -303,6 +306,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         }
     }
 
+    /** @group legacy */
     public function testRavenHandlerWhenADSNIsSpecified()
     {
         if (Logger::API !== 1) {
@@ -310,6 +314,8 @@ class MonologExtensionTest extends DependencyInjectionTestCase
 
             return;
         }
+
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "raven" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
 
         $dsn = 'http://43f6017361224d098402974103bfc53d:a6a0538fc2934ba2bed32e08741b2cd3@marca.python.live.cheggnet.com:9000/1';
 
@@ -329,6 +335,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RavenHandler');
     }
 
+    /** @group legacy */
     public function testRavenHandlerWhenADSNAndAClientAreSpecified()
     {
         if (Logger::API !== 1) {
@@ -336,6 +343,8 @@ class MonologExtensionTest extends DependencyInjectionTestCase
 
             return;
         }
+
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "raven" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
 
         $container = $this->getContainer([['handlers' => ['raven' => [
             'type' => 'raven', 'dsn' => 'foobar', 'client_id' => 'raven.client',
@@ -349,6 +358,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 'DEBUG', true]);
     }
 
+    /** @group legacy */
     public function testRavenHandlerWhenAClientIsSpecified()
     {
         if (Logger::API !== 1) {
@@ -356,6 +366,8 @@ class MonologExtensionTest extends DependencyInjectionTestCase
 
             return;
         }
+
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "raven" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
 
         $container = $this->getContainer([['handlers' => ['raven' => [
             'type' => 'raven', 'client_id' => 'raven.client',
@@ -377,8 +389,11 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->getContainer([['handlers' => ['sentry' => ['type' => 'sentry']]]]);
     }
 
+    /** @group legacy */
     public function testSentryHandlerWhenADSNIsSpecified()
     {
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "sentry" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
+
         $dsn = 'http://43f6017361224d098402974103bfc53d:a6a0538fc2934ba2bed32e08741b2cd3@marca.python.live.cheggnet.com:9000/1';
 
         $container = $this->getContainer([['handlers' => ['sentry' => [
@@ -401,8 +416,11 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($hub, [new Reference('monolog.sentry.client.'.sha1($dsn))]);
     }
 
+    /** @group legacy */
     public function testSentryHandlerWhenADSNAndAClientAreSpecified()
     {
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "sentry" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
+
         $container = $this->getContainer(
             [
                 [
@@ -433,8 +451,11 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($hub, [new Reference('sentry.client')]);
     }
 
+    /** @group legacy */
     public function testSentryHandlerWhenAClientIsSpecified()
     {
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "sentry" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
+
         $container = $this->getContainer(
             [
                 [
@@ -464,8 +485,11 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($hub, [new Reference('sentry.client')]);
     }
 
+    /** @group legacy */
     public function testSentryHandlerWhenAHubIsSpecified()
     {
+        $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "sentry" handler type is deprecated, use the "sentry/sentry-symfony" and a "service" handler instead.');
+
         $container = $this->getContainer(
             [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix https://github.com/symfony/monolog-bundle/pull/489#issuecomment-3340136619
| License       | MIT

The upgrade path is to use a "service" handler with `sentry/sentry-symfony` as documented:
https://docs.sentry.io/platforms/php/guides/symfony/logs/