### PR TITLE
Mark XML configuration tests as legacy

### DIFF
--- a/tests/DependencyInjection/XmlMonologExtensionTest.php
+++ b/tests/DependencyInjection/XmlMonologExtensionTest.php
@@ -16,6 +16,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
+/**
+ * XML configuration deprecated since Symfony 7.4.
+ *
+ * @group legacy
+ */
 class XmlMonologExtensionTest extends FixtureMonologExtensionTestCase
 {
     protected function loadFixture(ContainerBuilder $container, $fixture)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no (test only)
| New feature?  | no
| Deprecations? | no (deprecated by Symfony itself)
| Issues        | Related to https://github.com/symfony/symfony/pull/60568
| License       | MIT

Hide deprecation notices on Symfony 7.4 without asserting the deprecation message: 

```
  13x: Since symfony/dependency-injection 7.4: XML configuration format is deprecated, use YAML or PHP instead.
    1x in XmlMonologExtensionTest::testLoadWithSeveralHandlers from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    1x in XmlMonologExtensionTest::testLoadWithOverwriting from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    1x in XmlMonologExtensionTest::testLoadWithNewAtEnd from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    1x in XmlMonologExtensionTest::testLoadWithNewAndPriority from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    1x in XmlMonologExtensionTest::testHandlersWithChannels from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    ...

Remaining indirect deprecation notices (3)

  3x: Since symfony/dependency-injection 7.4: XML configuration format is deprecated, use YAML or PHP instead.
    1x in XmlMonologExtensionTest::testLoadWithOverwriting from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    1x in XmlMonologExtensionTest::testLoadWithNewAtEnd from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
    1x in XmlMonologExtensionTest::testLoadWithNewAndPriority from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
```
