### PR TITLE
Add PHP-DSL configuration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tests/var
 vendor
 .php-cs-fixer.cache
 composer.phar

--- a/tests/DependencyInjection/Fixtures/php/handlers.php
+++ b/tests/DependencyInjection/Fixtures/php/handlers.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('noop')
+        ->type('noop');
+};

--- a/tests/DependencyInjection/Fixtures/php/handlers_with_channels.php
+++ b/tests/DependencyInjection/Fixtures/php/handlers_with_channels.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set('security_logger', 'Foo')
+        ->tag('monolog.logger', ['channel' => 'security']);
+
+    $services->set('doctrine_logger', 'Foo')
+        ->tag('monolog.logger', ['channel' => 'doctrine']);
+
+    $services->set('foo_logger', 'Foo')
+        ->tag('monolog.logger', ['channel' => 'foo']);
+
+    $services->set('bar_logger', 'Foo')
+        ->tag('monolog.logger', ['channel' => 'bar']);
+
+    $containerConfigurator->extension('monolog', [
+        'handlers' => [
+            'custom' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'bubble' => false,
+                'level' => 'ERROR',
+                'channels' => 'foo',
+            ],
+            'main' => [
+                'type' => 'group',
+                'members' => [
+                    'nested',
+                ],
+                'channels' => [
+                    '!foo',
+                    '!bar',
+                ],
+            ],
+            'nested' => [
+                'type' => 'stream',
+            ],
+            'extra' => [
+                'type' => 'syslog',
+                'ident' => 'monolog',
+                'facility' => 'user',
+                'level' => 'ALERT',
+            ],
+            'more' => [
+                'type' => 'native_mailer',
+                'to_email' => 'monitoring@example.org',
+                'from_email' => 'webmaster@example.org',
+                'subject' => 'Monolog report',
+                'level' => 'CRITICAL',
+                'channels' => [
+                    'type' => 'inclusive',
+                    'elements' => [
+                        'security',
+                        'doctrine',
+                    ],
+                ],
+            ],
+        ],
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/multiple_email_recipients.php
+++ b/tests/DependencyInjection/Fixtures/php/multiple_email_recipients.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('swift')
+        ->type('swift_mailer')
+        ->fromEmail('error@example.com')
+        ->toEmail(['dev1@example.com', 'dev2@example.com'])
+        ->subject('An Error Occurred!')
+        ->level('debug');
+};

--- a/tests/DependencyInjection/Fixtures/php/multiple_handlers.php
+++ b/tests/DependencyInjection/Fixtures/php/multiple_handlers.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('custom')
+        ->type('stream')
+        ->path('/tmp/symfony.log')
+        ->bubble(false)
+        ->level('ERROR')
+        ->filePermission(438);
+
+    $monologConfig
+        ->handler('main')
+        ->type('fingers_crossed')
+        ->actionLevel('ERROR')
+        ->passthruLevel('NOTICE')
+        ->handler('nested');
+
+    $monologConfig
+        ->handler('nested')
+        ->type('stream');
+
+    $monologConfig
+        ->handler('filtered')
+        ->type('filter')
+        ->acceptedLevels(['WARNING', 'ERROR'])
+        ->handler('nested2');
+
+    $monologConfig
+        ->handler('nested2')
+        ->type('stream');
+};

--- a/tests/DependencyInjection/Fixtures/php/native_mailer.php
+++ b/tests/DependencyInjection/Fixtures/php/native_mailer.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('mailer')
+        ->type('native_mailer')
+        ->fromEmail('foo@example.com')
+        ->toEmail('bar@exemple.com')
+        ->subject('a subject')
+        ->headers(['Foo: bar', 'Baz: inga']);
+};

--- a/tests/DependencyInjection/Fixtures/php/new_and_priority.php
+++ b/tests/DependencyInjection/Fixtures/php/new_and_priority.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/new_and_priority_import.php');
+
+    $containerConfigurator->extension('monolog', [
+        'handlers' => [
+            'custom' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'bubble' => true,
+                'level' => 'WARNING',
+            ],
+            'first' => [
+                'type' => 'rotating_file',
+                'path' => '/tmp/monolog.log',
+                'bubble' => true,
+                'level' => 'ERROR',
+                'priority' => 3,
+            ],
+            'last' => [
+                'type' => 'stream',
+                'path' => '/tmp/last.log',
+                'bubble' => true,
+                'level' => 'ERROR',
+                'priority' => -3,
+            ],
+        ],
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/new_and_priority_import.php
+++ b/tests/DependencyInjection/Fixtures/php/new_and_priority_import.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('custom')
+        ->type('stream')
+        ->path('/tmp/symfony.log')
+        ->bubble(true)
+        ->level('ERROR');
+
+    $monologConfig
+        ->handler('main')
+        ->type('buffer')
+        ->level('INFO')
+        ->handler('nested');
+
+    $monologConfig
+        ->handler('nested')
+        ->type('stream');
+};

--- a/tests/DependencyInjection/Fixtures/php/new_at_end.php
+++ b/tests/DependencyInjection/Fixtures/php/new_at_end.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/new_at_end_import.php');
+
+    $containerConfigurator->extension('monolog', [
+        'handlers' => [
+            'custom' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'bubble' => false,
+                'level' => 'WARNING',
+            ],
+            'new' => [
+                'type' => 'stream',
+                'path' => '/tmp/monolog.log',
+                'bubble' => true,
+                'level' => 'ERROR',
+            ],
+        ],
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/new_at_end_import.php
+++ b/tests/DependencyInjection/Fixtures/php/new_at_end_import.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('custom')
+        ->type('stream')
+        ->path('/tmp/symfony.log')
+        ->bubble(true)
+        ->level('ERROR');
+
+    $monologConfig
+        ->handler('main')
+        ->type('fingers_crossed')
+        ->actionLevel('ERROR')
+        ->handler('nested');
+
+    $monologConfig
+        ->handler('nested')
+        ->type('stream');
+};

--- a/tests/DependencyInjection/Fixtures/php/overwriting.php
+++ b/tests/DependencyInjection/Fixtures/php/overwriting.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/overwriting_import.php');
+
+    $containerConfigurator->extension('monolog', [
+        'handlers' => [
+            'custom' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'bubble' => true,
+                'level' => 'WARNING',
+            ],
+        ],
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/overwriting_import.php
+++ b/tests/DependencyInjection/Fixtures/php/overwriting_import.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('custom')
+        ->type('stream')
+        ->path('/tmp/symfony.log')
+        ->bubble(false)
+        ->level('ERROR');
+
+    $monologConfig
+        ->handler('main')
+        ->type('fingers_crossed')
+        ->actionLevel('ERROR')
+        ->handler('nested');
+
+    $monologConfig
+        ->handler('nested')
+        ->type('stream');
+};

--- a/tests/DependencyInjection/Fixtures/php/parameterized_handlers.php
+++ b/tests/DependencyInjection/Fixtures/php/parameterized_handlers.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set('channel_parameter', 'some_channel');
+
+    $services = $containerConfigurator->services();
+
+    $services->set('foo_logger', 'Foo')
+        ->tag('monolog.logger', ['channel' => '%channel_parameter%']);
+
+    $containerConfigurator->extension('monolog', [
+        'handlers' => [
+            'custom' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'channels' => '%channel_parameter%',
+            ],
+        ],
+    ]);
+};

--- a/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_disabled.php
+++ b/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_disabled.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('custom')
+        ->type('stream')
+        ->path('/tmp/symfony.log')
+        ->processPsr3Messages(false);
+};

--- a/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_null.php
+++ b/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_null.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('custom')
+        ->type('noop')
+        ->processPsr3Messages(true);
+};

--- a/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_with_arguments.php
+++ b/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_with_arguments.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('with_arguments')
+        ->type('stream')
+        ->processPsr3Messages()
+        ->dateFormat('Y');
+
+    $monologConfig
+        ->handler('without_arguments')
+        ->type('stream')
+        ->processPsr3Messages()
+        ->enabled(true);
+};

--- a/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_without_arguments.php
+++ b/tests/DependencyInjection/Fixtures/php/process_psr_3_messages_without_arguments.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('without_arguments')
+        ->type('stream')
+        ->processPsr3Messages()
+        ->enabled(true);
+};

--- a/tests/DependencyInjection/Fixtures/php/server_log.php
+++ b/tests/DependencyInjection/Fixtures/php/server_log.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('server_log')
+        ->type('server_log')
+        ->host('0:9911');
+};

--- a/tests/DependencyInjection/Fixtures/php/single_email_recipient.php
+++ b/tests/DependencyInjection/Fixtures/php/single_email_recipient.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return static function (Symfony\Config\MonologConfig $monologConfig): void {
+    $monologConfig
+        ->handler('swift')
+        ->type('swift_mailer')
+        ->fromEmail('error@example.com')
+        ->toEmail('error@example.com')
+        ->subject('An Error Occurred!')
+        ->level('debug');
+};

--- a/tests/DependencyInjection/PhpMonologExtensionTest.php
+++ b/tests/DependencyInjection/PhpMonologExtensionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
+
+use Symfony\Bundle\MonologBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+class PhpMonologExtensionTest extends FixtureMonologExtensionTestCase
+{
+    protected function loadFixture(ContainerBuilder $container, $fixture)
+    {
+        $container->setDefinition('mailer', new Definition('Swiftmailer'));
+
+        $generator = new ConfigBuilderGenerator(__DIR__.'/../../var/cache');
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/Fixtures/php'), null, $generator);
+        $loader->load($fixture.'.php');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Test the configuration using PHP-DSL format. The XML format will be removed.

This tests also provide examples.