### PR TITLE
Skip XML config tests with Symfony 8.0

### DIFF
--- a/tests/DependencyInjection/XmlMonologExtensionTest.php
+++ b/tests/DependencyInjection/XmlMonologExtensionTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -19,11 +19,15 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 /**
  * XML configuration deprecated since Symfony 7.4.
  */
-#[Group('legacy')]
+#[IgnoreDeprecations]
 class XmlMonologExtensionTest extends FixtureMonologExtensionTestCase
 {
     protected function loadFixture(ContainerBuilder $container, string $fixture)
     {
+        if (!class_exists(XmlFileLoader::class)) {
+            $this->markTestSkipped('The XML configuration has been removed in Symfony 8.0.');
+        }
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml'));
         $loader->load($fixture.'.xml');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Related to https://github.com/symfony/symfony/pull/60568
| License       | MIT

Follow-up:
- https://github.com/symfony/monolog-bundle/pull/541

As soon as we keep support for Symfony 7.4, we must keep the tests on XML config format.