### PR TITLE
Fix `hosts` key in Elastic 8 configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -908,6 +908,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->children()
                         ->scalarNode('id')->end()
+                        ->arrayNode('hosts')->prototype('scalar')->end()->end()
                         ->scalarNode('host')->end()
                         ->scalarNode('port')->defaultValue(9200)->end()
                         ->scalarNode('transport')->defaultValue('Http')->end()
@@ -916,7 +917,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->validate()
                     ->ifTrue(function ($v) {
-                        return !isset($v['id']) && !isset($v['host']);
+                        return !isset($v['id']) && !isset($v['host']) && !isset($v['hosts']);
                     })
                     ->thenInvalid('What must be set is either the host or the id.')
                     ->end()

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -304,7 +304,7 @@ class MonologExtension extends Extension
                         $factory = class_exists('Elastic\Elasticsearch\ClientBuilder') ? 'Elastic\Elasticsearch\ClientBuilder' : 'Elasticsearch\ClientBuilder';
                         $client->setFactory([$factory, 'fromConfig']);
                         $clientArguments = [
-                            'hosts' => [$handler['elasticsearch']['host']],
+                            'hosts' => $handler['elasticsearch']['hosts'] ?? [$handler['elasticsearch']['host']],
                         ];
 
                         if (isset($handler['elasticsearch']['user'], $handler['elasticsearch']['password'])) {
@@ -313,11 +313,18 @@ class MonologExtension extends Extension
                     } else {
                         $client = new Definition('Elastica\Client');
 
-                        $clientArguments = [
-                            'host' => $handler['elasticsearch']['host'],
-                            'port' => $handler['elasticsearch']['port'],
-                            'transport' => $handler['elasticsearch']['transport'],
-                        ];
+                        if (isset($handler['elasticsearch']['hosts'])) {
+                            $clientArguments = [
+                                'hosts' => $handler['elasticsearch']['hosts'],
+                                'transport' => $handler['elasticsearch']['transport'],
+                            ];
+                        } else {
+                            $clientArguments = [
+                                'host' => $handler['elasticsearch']['host'],
+                                'port' => $handler['elasticsearch']['port'],
+                                'transport' => $handler['elasticsearch']['transport'],
+                            ];
+                        }
 
                         if (isset($handler['elasticsearch']['user'], $handler['elasticsearch']['password'])) {
                             $clientArguments['headers'] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #499
| License       | MIT

Elastica 8+ client has an option `hosts` instead of `host` (https://github.com/ruflin/Elastica/pull/2188).

Adding a new `monolog.handlers.(elastica|elastic_search).elasticsearch.hosts` setting that is a list of strings.

This way, we don't try to detect which version of elastica is used, an let the developers set the correct configuration depending on the version they have installed.