### PR TITLE
Support `null` for the `NullHandler`

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -451,10 +451,9 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('type')
                     ->isRequired()
-                    ->treatNullLike('null')
                     ->beforeNormalization()
-                        ->always()
-                        ->then(function ($v) { return strtolower($v); })
+                        ->ifString()->then(function ($v) { return strtolower($v); })
+                        ->ifNull()->then(function ($v) { return 'null'; })
                     ->end()
                 ->end()
                 ->scalarNode('id')->end() // service & rollbar

--- a/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
+++ b/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Handler\NoopHandler;
+use Monolog\Handler\NullHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
@@ -310,6 +311,16 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
 
         $this->assertCount(2, $methodCalls);
         $this->assertSame(['addHeader', [['Foo: bar', 'Baz: inga']]], $methodCalls[1]);
+    }
+
+    public function testTypeNull()
+    {
+        $container = $this->getContainer('type_null');
+
+        $logger = $container->getDefinition('monolog.handler.null_handler');
+
+        $this->assertSame(NullHandler::class, $logger->getClass());
+        $this->assertSame('DEBUG', $logger->getArgument(0));
     }
 
     protected function getContainer($fixture)

--- a/tests/DependencyInjection/Fixtures/xml/type_null.xml
+++ b/tests/DependencyInjection/Fixtures/xml/type_null.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:monolog="http://symfony.com/schema/dic/monolog"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <monolog:config>
+        <monolog:handler
+            name="null_handler"
+            type="null" />
+    </monolog:config>
+</container>

--- a/tests/DependencyInjection/Fixtures/yml/type_null.yml
+++ b/tests/DependencyInjection/Fixtures/yml/type_null.yml
@@ -1,0 +1,4 @@
+monolog:
+    handlers:
+        null_handler:
+            type: null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #400 Fix #133
| License       | MIT

The XML config format doesn't support `'null'` string as its always converted to `NULL`, and Yaml requires `'null'` to be quoted.
In order to simplify the configuration, the `NULL` value is converted to `'null'` string by the configuration.