### PR TITLE
Deprecate "mongo" handler type in favor of new "mongodb" syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
                 php: [ '8.1', '8.2', '8.3', '8.4' ]
                 monolog: [ '2.*' ]
                 symfony: [ false ]
+                extensions: [ '' ]
                 include:
                     -   php: '8.1'
                         deps: lowest
@@ -26,6 +27,8 @@ jobs:
                     -   php: '8.4'
                         deps: highest
                         monolog: '3.*'
+                    -   php: '8.4'
+                        extensions: mongodb
 
         env:
             SYMFONY_REQUIRE: ${{ matrix.symfony }}
@@ -40,6 +43,7 @@ jobs:
                     php-version: ${{ matrix.php }}
                     ini-values: zend.exception_ignore_args=false
                     tools: flex
+                    extensions: ${{ matrix.extensions }}
 
             -   name: Configure composer
                 if: "${{ matrix.deps == 'highest' }}"
@@ -48,6 +52,10 @@ jobs:
             -   name: Require Monolog version
                 if: "${{ matrix.monolog != '' }}"
                 run: composer require --no-update monolog/monolog:${{ matrix.monolog }}
+
+            -   name: Require mongodb/mongodb if ext-mongodb is available
+                if: "${{ contains(matrix.extensions, 'mongodb') }}"
+                run: composer require --no-update mongodb/mongodb
 
             -   name: Composer install
                 uses: ramsey/composer-install@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add `hosts` configuration for `elastica` handler
 * Add `enabled` option to `handlers` configuration
 * Add `priority` field to `processor` tag
+* Add `mongodb` handler and deprecate `mongo`
 
 ## 3.10.0 (2023-11-06)
 

--- a/config/schema/monolog-1.0.xsd
+++ b/config/schema/monolog-1.0.xsd
@@ -21,6 +21,7 @@
             <xsd:element name="channels" type="channels" minOccurs="0" maxOccurs="1" />
             <xsd:element name="publisher" type="publisher" minOccurs="0" maxOccurs="1" />
             <xsd:element name="mongo" type="mongo" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="mongodb" type="mongodb" minOccurs="0" maxOccurs="1" />
             <xsd:element name="elasticsearch" type="elasticsearch" minOccurs="0" maxOccurs="1" />
             <xsd:element name="config" type="xsd:anyType" minOccurs="0" maxOccurs="1" />
             <xsd:element name="excluded-404" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
@@ -159,6 +160,15 @@
         <xsd:attribute name="port" type="xsd:integer" />
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="pass" type="xsd:string" />
+        <xsd:attribute name="database" type="xsd:string" />
+        <xsd:attribute name="collection" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="mongodb">
+        <xsd:attribute name="id" type="xsd:string" />
+        <xsd:attribute name="uri" type="xsd:string" />
+        <xsd:attribute name="username" type="xsd:string" />
+        <xsd:attribute name="password" type="xsd:string" />
         <xsd:attribute name="database" type="xsd:string" />
         <xsd:attribute name="collection" type="xsd:string" />
     </xsd:complexType>

--- a/tests/DependencyInjection/Fixtures/xml/mongodb.xml
+++ b/tests/DependencyInjection/Fixtures/xml/mongodb.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/monolog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <config>
+        <handler name="mongodb" type="mongodb">
+            <mongodb uri="mongodb://localhost:27018" username="username" password="password" database="db" collection="coll" />
+        </handler>
+    </config>
+</srv:container>

--- a/tests/DependencyInjection/Fixtures/yml/mongodb.yml
+++ b/tests/DependencyInjection/Fixtures/yml/mongodb.yml
@@ -1,0 +1,10 @@
+monolog:
+    handlers:
+        mongodb:
+            type: mongodb
+            mongodb:
+                uri: "mongodb://localhost:27018"
+                username: username
+                password: password
+                database: db
+                collection: coll


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x <!-- for features and bug -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | [PHPORM-398](https://jira.mongodb.org/browse/PHPORM-398)
| License       | MIT

Define a new "mongodb" handler type. It accepts an "id" reference like the old "mongo" type; however, "uri" instead of a single "host" and "port". The "uri" option is more flexible.

Additionally, the "username" and "password" options have been renamed and are no longer used to modify the connection string directly ("mongo" never applied URL encoding). Instead, the options are set in the URI options array, which does not require encoding. The "mongodb" never requires a password, as a username alone is valid for some auth mechanisms.

Lastly, a "monolog-bundle" app name is specified when the bundle constructs a MongoDB\Client instance for both "mongo" and "mongodb" handler syntax.