### PR TITLE
Remove support for the `DebugHandler`

### DIFF
--- a/CHANGELOG-4.md
+++ b/CHANGELOG-4.md
@@ -12,3 +12,4 @@
 * Remove `elasticsearch` type, use `elastica` or `elastic_search` instead
 * Remove `sentry` and `raven` types, use a `service` type with [`sentry/sentry-symfony`](https://docs.sentryio/platforms/php/guides/symfony/logs/) instead
 * Remove `DebugHandlerPass`
+* Remove support for the `DebugHandler`

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -730,7 +730,6 @@ final class MonologExtension extends Extension
             case 'test':
             case 'null':
             case 'noop':
-            case 'debug':
                 $definition->setArguments([
                     $handler['level'],
                     $handler['bubble'],
@@ -796,7 +795,6 @@ final class MonologExtension extends Extension
             'browser_console' => 'Monolog\Handler\BrowserConsoleHandler',
             'firephp' => 'Symfony\Bridge\Monolog\Handler\FirePHPHandler',
             'chromephp' => 'Symfony\Bridge\Monolog\Handler\ChromePhpHandler',
-            'debug' => 'Symfony\Bridge\Monolog\Handler\DebugHandler',
             'native_mailer' => 'Monolog\Handler\NativeMailerHandler',
             'symfony_mailer' => 'Symfony\Bridge\Monolog\Handler\MailerHandler',
             'socket' => 'Monolog\Handler\SocketHandler',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `DebugHandler` was [removed way back in Symfony 4.0](https://github.com/symfony/symfony/pull/20416). Since the bundle only supports >=6.4, this is no longer needed.

This was an oversight in #526.