### PR TITLE
Use `::class` constant

### DIFF
--- a/src/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/src/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -75,7 +75,7 @@ class LoggerChannelPass implements CompilerPassInterface
                 $binding->setValues($values);
 
                 $bindings = $definition->getBindings();
-                $bindings['Psr\Log\LoggerInterface'] = $binding;
+                $bindings[LoggerInterface::class] = $binding;
                 $definition->setBindings($bindings);
             }
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -988,7 +988,7 @@ final class Configuration implements ConfigurationInterface
                         ->always(function ($v) {
                             $map = [];
                             foreach ($v as $verbosity => $level) {
-                                $verbosityConstant = 'Symfony\Component\Console\Output\OutputInterface::'.$verbosity;
+                                $verbosityConstant = \Symfony\Component\Console\Output\OutputInterface::class.'::'.$verbosity;
 
                                 if (!\defined($verbosityConstant)) {
                                     throw new InvalidConfigurationException(\sprintf('The configured verbosity "%s" is invalid as it is not defined in Symfony\Component\Console\Output\OutputInterface.', $verbosity));

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -18,7 +18,9 @@ use Monolog\Handler\HandlerInterface;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Monolog\ResettableInterface;
+use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -146,7 +148,7 @@ final class MonologExtension extends Extension
         $definition = new Definition($handlerClass);
 
         if ($handler['include_stacktraces']) {
-            $definition->setConfigurator(['Symfony\\Bundle\\MonologBundle\\MonologBundle', 'includeStacktraces']);
+            $definition->setConfigurator([MonologBundle::class, 'includeStacktraces']);
         }
 
         if (null === $handler['process_psr_3_messages']['enabled']) {
@@ -192,8 +194,8 @@ final class MonologExtension extends Extension
             case 'gelf':
                 if (isset($handler['publisher']['id'])) {
                     $publisher = new Reference($handler['publisher']['id']);
-                } elseif (class_exists('Gelf\Transport\UdpTransport')) {
-                    $transport = new Definition("Gelf\Transport\UdpTransport", [
+                } elseif (class_exists(\Gelf\Transport\UdpTransport::class)) {
+                    $transport = new Definition(\Gelf\Transport\UdpTransport::class, [
                         $handler['publisher']['hostname'],
                         $handler['publisher']['port'],
                         $handler['publisher']['chunk_size'],
@@ -202,9 +204,9 @@ final class MonologExtension extends Extension
 
                     if (isset($handler['publisher']['encoder'])) {
                         if ('compressed_json' === $handler['publisher']['encoder']) {
-                            $encoderClass = 'Gelf\Encoder\CompressedJsonEncoder';
+                            $encoderClass = \Gelf\Encoder\CompressedJsonEncoder::class;
                         } elseif ('json' === $handler['publisher']['encoder']) {
-                            $encoderClass = 'Gelf\Encoder\JsonEncoder';
+                            $encoderClass = \Gelf\Encoder\JsonEncoder::class;
                         } else {
                             throw new \RuntimeException('The gelf message encoder must be either "compressed_json" or "json".');
                         }
@@ -215,7 +217,7 @@ final class MonologExtension extends Extension
                         $transport->addMethodCall('setMessageEncoder', [$encoder]);
                     }
 
-                    $publisher = new Definition('Gelf\Publisher', []);
+                    $publisher = new Definition(\Gelf\Publisher::class, []);
                     $publisher->addMethodCall('addTransport', [$transport]);
                     $publisher->setPublic(false);
                 } else {
@@ -232,7 +234,7 @@ final class MonologExtension extends Extension
             case 'mongo':
                 trigger_deprecation('symfony/monolog-bundle', '3.11', 'The "mongo" handler type is deprecated in MonologBundle since version 3.11.0, use the "mongodb" type instead.');
 
-                if (!class_exists('MongoDB\Client')) {
+                if (!class_exists(\MongoDB\Client::class)) {
                     throw new \RuntimeException('The "mongo" handler requires the mongodb/mongodb package to be installed.');
                 }
 
@@ -247,7 +249,7 @@ final class MonologExtension extends Extension
 
                     $server .= $handler['mongo']['host'].':'.$handler['mongo']['port'];
 
-                    $client = new Definition('MongoDB\Client', [
+                    $client = new Definition(\MongoDB\Client::class, [
                         $server,
                         ['appname' => 'monolog-bundle'],
                     ]);
@@ -263,7 +265,7 @@ final class MonologExtension extends Extension
                 break;
 
             case 'mongodb':
-                if (!class_exists('MongoDB\Client')) {
+                if (!class_exists(\MongoDB\Client::class)) {
                     throw new \RuntimeException('The "mongodb" handler requires the mongodb/mongodb package to be installed.');
                 }
 
@@ -280,7 +282,7 @@ final class MonologExtension extends Extension
                         $uriOptions['password'] = $handler['mongodb']['password'];
                     }
 
-                    $client = new Definition('MongoDB\Client', [
+                    $client = new Definition(\MongoDB\Client::class, [
                         $handler['mongodb']['uri'],
                         $uriOptions,
                     ]);
@@ -295,7 +297,7 @@ final class MonologExtension extends Extension
                 ]);
 
                 if (empty($handler['formatter'])) {
-                    $formatter = new Definition('Monolog\Formatter\MongoDBFormatter');
+                    $formatter = new Definition(\Monolog\Formatter\MongoDBFormatter::class);
                     $definition->addMethodCall('setFormatter', [$formatter]);
                 }
                 break;
@@ -311,8 +313,8 @@ final class MonologExtension extends Extension
                 } else {
                     if ('elastic_search' === $handler['type']) {
                         // v8 has a new Elastic\ prefix
-                        $client = new Definition(class_exists('Elastic\Elasticsearch\Client') ? 'Elastic\Elasticsearch\Client' : 'Elasticsearch\Client');
-                        $factory = class_exists('Elastic\Elasticsearch\ClientBuilder') ? 'Elastic\Elasticsearch\ClientBuilder' : 'Elasticsearch\ClientBuilder';
+                        $client = new Definition(class_exists(\Elastic\Elasticsearch\Client::class) ? \Elastic\Elasticsearch\Client::class : \Elasticsearch\Client::class);
+                        $factory = class_exists(\Elastic\Elasticsearch\ClientBuilder::class) ? \Elastic\Elasticsearch\ClientBuilder::class : \Elasticsearch\ClientBuilder::class;
                         $client->setFactory([$factory, 'fromConfig']);
                         $clientArguments = [
                             'hosts' => $handler['elasticsearch']['hosts'] ?? [$handler['elasticsearch']['host']],
@@ -322,7 +324,7 @@ final class MonologExtension extends Extension
                             $clientArguments['basicAuthentication'] = [$handler['elasticsearch']['user'], $handler['elasticsearch']['password']];
                         }
                     } else {
-                        $client = new Definition('Elastica\Client');
+                        $client = new Definition(\Elastica\Client::class);
 
                         if (isset($handler['elasticsearch']['hosts'])) {
                             $clientArguments = [
@@ -441,7 +443,7 @@ final class MonologExtension extends Extension
                 if (isset($handler['activation_strategy'])) {
                     $activation = new Reference($handler['activation_strategy']);
                 } elseif (!empty($handler['excluded_http_codes'])) {
-                    $activationDef = new Definition('Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy', [
+                    $activationDef = new Definition(HttpCodeActivationStrategy::class, [
                         new Reference('request_stack'),
                         $handler['excluded_http_codes'],
                         $activation,
@@ -561,7 +563,7 @@ final class MonologExtension extends Extension
                         $prototype = new Reference($handler['email_prototype']['id']);
                     }
                 } else {
-                    $prototype = (new Definition('Symfony\Component\Mime\Email'))
+                    $prototype = (new Definition(\Symfony\Component\Mime\Email::class))
                         ->setPublic(false)
                         ->addMethodCall('from', [$handler['from_email']])
                         ->addMethodCall('to', $handler['to_email'])
@@ -713,7 +715,7 @@ final class MonologExtension extends Extension
                 ]);
 
                 if (empty($handler['formatter'])) {
-                    $formatter = new Definition("Monolog\Formatter\FlowdockFormatter", [
+                    $formatter = new Definition(\Monolog\Formatter\FlowdockFormatter::class, [
                         $handler['source'],
                         $handler['from_email'],
                     ]);
@@ -731,7 +733,7 @@ final class MonologExtension extends Extension
                 } else {
                     $config = $handler['config'] ?: [];
                     $config['access_token'] = $handler['token'];
-                    $rollbar = new Definition('RollbarNotifier', [
+                    $rollbar = new Definition(\RollbarNotifier::class, [
                         $config,
                     ]);
                     $rollbarId = 'monolog.rollbar.notifier.'.sha1(json_encode($config));
@@ -826,48 +828,47 @@ final class MonologExtension extends Extension
     private function getHandlerClassByType(string $handlerType): string
     {
         return match ($handlerType) {
-            'stream' => 'Monolog\Handler\StreamHandler',
-            'console' => 'Symfony\Bridge\Monolog\Handler\ConsoleHandler',
-            'group' => 'Monolog\Handler\GroupHandler',
-            'buffer' => 'Monolog\Handler\BufferHandler',
-            'deduplication' => 'Monolog\Handler\DeduplicationHandler',
-            'rotating_file' => 'Monolog\Handler\RotatingFileHandler',
-            'syslog' => 'Monolog\Handler\SyslogHandler',
-            'syslogudp' => 'Monolog\Handler\SyslogUdpHandler',
-            'null' => 'Monolog\Handler\NullHandler',
-            'test' => 'Monolog\Handler\TestHandler',
-            'gelf' => 'Monolog\Handler\GelfHandler',
-            'rollbar' => 'Monolog\Handler\RollbarHandler',
-            'flowdock' => 'Monolog\Handler\FlowdockHandler',
-            'browser_console' => 'Monolog\Handler\BrowserConsoleHandler',
-            'firephp' => 'Symfony\Bridge\Monolog\Handler\FirePHPHandler',
-            'chromephp' => 'Symfony\Bridge\Monolog\Handler\ChromePhpHandler',
-            'native_mailer' => 'Monolog\Handler\NativeMailerHandler',
-            'symfony_mailer' => 'Symfony\Bridge\Monolog\Handler\MailerHandler',
-            'socket' => 'Monolog\Handler\SocketHandler',
-            'pushover' => 'Monolog\Handler\PushoverHandler',
-            'newrelic' => 'Monolog\Handler\NewRelicHandler',
-            'slack' => 'Monolog\Handler\SlackHandler',
-            'slackwebhook' => 'Monolog\Handler\SlackWebhookHandler',
-            'cube' => 'Monolog\Handler\CubeHandler',
-            'amqp' => 'Monolog\Handler\AmqpHandler',
-            'error_log' => 'Monolog\Handler\ErrorLogHandler',
-            'loggly' => 'Monolog\Handler\LogglyHandler',
-            'logentries' => 'Monolog\Handler\LogEntriesHandler',
-            'whatfailuregroup' => 'Monolog\Handler\WhatFailureGroupHandler',
-            'fingers_crossed' => 'Monolog\Handler\FingersCrossedHandler',
-            'filter' => 'Monolog\Handler\FilterHandler',
-            'mongo' => 'Monolog\Handler\MongoDBHandler',
-            'mongodb' => 'Monolog\Handler\MongoDBHandler',
-            'telegram' => 'Monolog\Handler\TelegramBotHandler',
-            'server_log' => 'Symfony\Bridge\Monolog\Handler\ServerLogHandler',
-            'redis', 'predis' => 'Monolog\Handler\RedisHandler',
-            'insightops' => 'Monolog\Handler\InsightOpsHandler',
-            'sampling' => 'Monolog\Handler\SamplingHandler',
-            'elastica' => 'Monolog\Handler\ElasticaHandler',
-            'elastic_search' => 'Monolog\Handler\ElasticsearchHandler',
-            'fallbackgroup' => 'Monolog\Handler\FallbackGroupHandler',
-            'noop' => 'Monolog\Handler\NoopHandler',
+            'stream' => \Monolog\Handler\StreamHandler::class,
+            'console' => \Symfony\Bridge\Monolog\Handler\ConsoleHandler::class,
+            'group' => \Monolog\Handler\GroupHandler::class,
+            'buffer' => \Monolog\Handler\BufferHandler::class,
+            'deduplication' => \Monolog\Handler\DeduplicationHandler::class,
+            'rotating_file' => \Monolog\Handler\RotatingFileHandler::class,
+            'syslog' => \Monolog\Handler\SyslogHandler::class,
+            'syslogudp' => \Monolog\Handler\SyslogUdpHandler::class,
+            'null' => \Monolog\Handler\NullHandler::class,
+            'test' => \Monolog\Handler\TestHandler::class,
+            'gelf' => \Monolog\Handler\GelfHandler::class,
+            'rollbar' => \Monolog\Handler\RollbarHandler::class,
+            'flowdock' => \Monolog\Handler\FlowdockHandler::class,
+            'browser_console' => \Monolog\Handler\BrowserConsoleHandler::class,
+            'firephp' => \Symfony\Bridge\Monolog\Handler\FirePHPHandler::class,
+            'chromephp' => \Symfony\Bridge\Monolog\Handler\ChromePhpHandler::class,
+            'native_mailer' => \Monolog\Handler\NativeMailerHandler::class,
+            'symfony_mailer' => \Symfony\Bridge\Monolog\Handler\MailerHandler::class,
+            'socket' => \Monolog\Handler\SocketHandler::class,
+            'pushover' => \Monolog\Handler\PushoverHandler::class,
+            'newrelic' => \Monolog\Handler\NewRelicHandler::class,
+            'slack' => \Monolog\Handler\SlackHandler::class,
+            'slackwebhook' => \Monolog\Handler\SlackWebhookHandler::class,
+            'cube' => \Monolog\Handler\CubeHandler::class,
+            'amqp' => \Monolog\Handler\AmqpHandler::class,
+            'error_log' => \Monolog\Handler\ErrorLogHandler::class,
+            'loggly' => \Monolog\Handler\LogglyHandler::class,
+            'logentries' => \Monolog\Handler\LogEntriesHandler::class,
+            'whatfailuregroup' => \Monolog\Handler\WhatFailureGroupHandler::class,
+            'fingers_crossed' => \Monolog\Handler\FingersCrossedHandler::class,
+            'filter' => \Monolog\Handler\FilterHandler::class,
+            'mongo','mongodb' => \Monolog\Handler\MongoDBHandler::class,
+            'telegram' => \Monolog\Handler\TelegramBotHandler::class,
+            'server_log' => \Symfony\Bridge\Monolog\Handler\ServerLogHandler::class,
+            'redis', 'predis' => \Monolog\Handler\RedisHandler::class,
+            'insightops' => \Monolog\Handler\InsightOpsHandler::class,
+            'sampling' => \Monolog\Handler\SamplingHandler::class,
+            'elastica' => \Monolog\Handler\ElasticaHandler::class,
+            'elastic_search' => \Monolog\Handler\ElasticsearchHandler::class,
+            'fallbackgroup' => \Monolog\Handler\FallbackGroupHandler::class,
+            'noop' => \Monolog\Handler\NoopHandler::class,
             default => throw new \InvalidArgumentException(\sprintf('There is no handler class defined for handler "%s".', $handlerType)),
         };
     }

--- a/tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -81,7 +81,7 @@ class LoggerChannelPassTest extends TestCase
     {
         $container = $this->getFunctionalContainer();
 
-        $dummyService = $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
+        $dummyService = $container->register('dummy_service', DummyService::class)
             ->setAutowired(true)
             ->setPublic(true)
             ->addTag('monolog.logger', ['channel' => 'test']);
@@ -95,10 +95,10 @@ class LoggerChannelPassTest extends TestCase
     {
         $container = $this->getFunctionalContainer();
 
-        $container->registerForAutoconfiguration('Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
+        $container->registerForAutoconfiguration(DummyService::class)
             ->setProperty('fake', 'dummy');
 
-        $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
+        $container->register('dummy_service', DummyService::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)
             ->setPublic(true)
@@ -113,7 +113,7 @@ class LoggerChannelPassTest extends TestCase
     {
         $container = $this->getFunctionalContainer();
 
-        $dummyService = $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
+        $dummyService = $container->register('dummy_service', DummyService::class)
             ->setAutowired(true)
             ->addArgument(new Reference('monolog.logger'))
             ->addTag('monolog.logger', ['channel' => 'test']);
@@ -127,7 +127,7 @@ class LoggerChannelPassTest extends TestCase
     {
         $container = $this->getFunctionalContainer();
 
-        $dummyService = $container->register('dummy_service', 'stdClass')
+        $dummyService = $container->register('dummy_service', \stdClass::class)
             ->addTag('monolog.logger', ['channel' => 'test']);
 
         $container->compile();

--- a/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
+++ b/tests/DependencyInjection/FixtureMonologExtensionTestCase.php
@@ -41,15 +41,15 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, false]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\FingersCrossedHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), $activation, 0, true, true, 'NOTICE']);
 
         $handler = $container->getDefinition('monolog.handler.filtered');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FilterHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\FilterHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), ['WARNING', 'ERROR'], 'EMERGENCY', true]);
     }
 
@@ -70,11 +70,11 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'WARNING', true, null, false]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\FingersCrossedHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), $activation, 0, true, true, null]);
     }
 
@@ -96,7 +96,7 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.new');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', 'ERROR', true, null, false]);
     }
 
@@ -120,15 +120,15 @@ abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCa
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\BufferHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\BufferHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), 0, 'INFO', true, false]);
 
         $handler = $container->getDefinition('monolog.handler.first');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RotatingFileHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\RotatingFileHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', 0, 'ERROR', true, null, false]);
 
         $handler = $container->getDefinition('monolog.handler.last');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/last.log', 'ERROR', true, null, false]);
     }
 

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -46,7 +46,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['%kernel.logs_dir%/%kernel.environment%.log', 'DEBUG', true, null, false]);
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
     }
@@ -64,7 +64,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, true]);
     }
 
@@ -84,7 +84,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\StreamHandler::class);
         $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, false]);
     }
 
@@ -92,7 +92,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     {
         $container = $this->getContainer(
             [['handlers' => ['custom' => ['type' => 'service', 'id' => 'some.service.id']]]],
-            ['some.service.id' => new Definition('stdClass', ['foo', false])]
+            ['some.service.id' => new Definition(\stdClass::class, ['foo', false])]
         );
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
@@ -104,7 +104,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
 
         $handler = $container->findDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, 'stdClass');
+        $this->assertDICDefinitionClass($handler, \stdClass::class);
         $this->assertDICConstructorArguments($handler, ['foo', false]);
     }
 
@@ -112,7 +112,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     {
         $container = $this->getContainer(
             [['handlers' => ['custom' => ['type' => 'service', 'id' => 'some.service.id', 'nested' => true]]]],
-            ['some.service.id' => new Definition('stdClass', ['foo', false])]
+            ['some.service.id' => new Definition(\stdClass::class, ['foo', false])]
         );
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
@@ -124,7 +124,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->findDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, 'stdClass');
+        $this->assertDICDefinitionClass($handler, \stdClass::class);
         $this->assertDICConstructorArguments($handler, ['foo', false]);
     }
 
@@ -221,7 +221,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SyslogHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\SyslogHandler::class);
         $this->assertDICConstructorArguments($handler, [false, 'user', 'DEBUG', true, \LOG_CONS]);
     }
 
@@ -237,7 +237,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
+        $this->assertDICDefinitionClass($handler, RollbarHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), 'DEBUG', true]);
     }
 
@@ -256,7 +256,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
+        $this->assertDICDefinitionClass($handler, RollbarHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('my_rollbar_id'), 'DEBUG', true]);
     }
 
@@ -281,7 +281,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.socket')]);
 
         $handler = $container->getDefinition('monolog.handler.socket');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SocketHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\SocketHandler::class);
         $this->assertDICConstructorArguments($handler, ['localhost:50505', 'DEBUG', true]);
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTimeout', ['1']);
@@ -318,7 +318,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.loggly')]);
         $handler = $container->getDefinition('monolog.handler.loggly');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\LogglyHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\LogglyHandler::class);
         $this->assertDICConstructorArguments($handler, [$token, 'DEBUG', true]);
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
 
@@ -353,7 +353,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $strategy = $container->getDefinition('monolog.handler.main.http_code_strategy');
-        $this->assertDICDefinitionClass($strategy, 'Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy');
+        $this->assertDICDefinitionClass($strategy, \Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy::class);
         $this->assertDICConstructorArguments($strategy, [
             new Reference('request_stack'),
             [
@@ -365,7 +365,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         ]);
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
+        $this->assertDICDefinitionClass($handler, \Monolog\Handler\FingersCrossedHandler::class);
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null]);
     }
 
@@ -391,7 +391,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
             'browser console with parameter level' => [
                 ['%log_level%' => 'info'],
                 ['type' => 'browser_console', 'level' => '%log_level%'],
-                'Monolog\Handler\BrowserConsoleHandler',
+                \Monolog\Handler\BrowserConsoleHandler::class,
                 [
                     '%log_level%',
                     true,
@@ -400,7 +400,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
             'browser console with envvar level' => [
                 ['%env(LOG_LEVEL)%' => 'info'],
                 ['type' => 'browser_console', 'level' => '%env(LOG_LEVEL)%'],
-                'Monolog\Handler\BrowserConsoleHandler',
+                \Monolog\Handler\BrowserConsoleHandler::class,
                 [
                     '%env(LOG_LEVEL)%',
                     true,
@@ -409,7 +409,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
             'stream with envvar level null or "~" (in yaml config)' => [
                 ['%env(LOG_LEVEL)%' => null],
                 ['type' => 'stream', 'level' => '%env(LOG_LEVEL)%'],
-                'Monolog\Handler\StreamHandler',
+                \Monolog\Handler\StreamHandler::class,
                 [
                     '%kernel.logs_dir%/%kernel.environment%.log',
                     '%env(LOG_LEVEL)%',
@@ -421,7 +421,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
             'stream with envvar level' => [
                 ['%env(LOG_LEVEL)%' => '400'],
                 ['type' => 'stream', 'level' => '%env(LOG_LEVEL)%'],
-                'Monolog\Handler\StreamHandler',
+                \Monolog\Handler\StreamHandler::class,
                 [
                     '%kernel.logs_dir%/%kernel.environment%.log',
                     '%env(LOG_LEVEL)%',
@@ -433,7 +433,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
             'stream with envvar and fallback parameter' => [
                 ['%env(LOG_LEVEL)%' => '500', '%log_level%' => '%env(LOG_LEVEL)%'],
                 ['type' => 'stream', 'level' => '%log_level%'],
-                'Monolog\Handler\StreamHandler',
+                \Monolog\Handler\StreamHandler::class,
                 [
                     '%kernel.logs_dir%/%kernel.environment%.log',
                     '%log_level%',
@@ -447,9 +447,6 @@ class MonologExtensionTest extends DependencyInjectionTestCase
 
     public function testProcessorAutoConfiguration()
     {
-        if (!interface_exists('Monolog\ResettableInterface')) {
-            $this->markTestSkipped('The ResettableInterface is not available.');
-        }
         $service = new Definition(UidProcessor::class);
         $service->setAutoconfigured(true);
         $container = $this->getContainer([], ['processor.uid' => $service]);
@@ -512,8 +509,8 @@ class MonologExtensionTest extends DependencyInjectionTestCase
     public function testElasticsearchAndElasticaHandlers()
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('elasticsearch.client', new Definition('Elasticsearch\\Client'));
-        $container->setDefinition('elastica.client', new Definition('Elastica\\Client'));
+        $container->setDefinition('elasticsearch.client', new Definition(\Elasticsearch\Client::class));
+        $container->setDefinition('elastica.client', new Definition(\Elastica\Client::class));
 
         $config = [[
             'handlers' => [
@@ -547,7 +544,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertSame(ElasticsearchHandler::class, $esHandler->getClass());
         $esClient = $esHandler->getArgument(0);
         $this->assertInstanceOf(Definition::class, $esClient);
-        $this->assertStringEndsWith('Elasticsearch\Client', $esClient->getClass());
+        $this->assertStringEndsWith(\Elasticsearch\Client::class, $esClient->getClass());
         $this->assertSame(['hosts' => ['es:9200']], $esClient->getArgument(0));
 
         // Elastica handler should receive the elastica.client as first argument
@@ -555,7 +552,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertSame(ElasticaHandler::class, $elasticaHandler->getClass());
         $elasticaClient = $elasticaHandler->getArgument(0);
         $this->assertInstanceOf(Definition::class, $elasticaClient);
-        $this->assertSame('Elastica\Client', $elasticaClient->getClass());
+        $this->assertSame(\Elastica\Client::class, $elasticaClient->getClass());
         $this->assertSame(['hosts' => ['es:9200'], 'transport' => 'Http'], $elasticaClient->getArgument(0));
     }
 
@@ -567,7 +564,7 @@ class MonologExtensionTest extends DependencyInjectionTestCase
             $this->markTestSkipped('mongodb/mongodb is not installed.');
         }
 
-        //$this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "mongo" handler type is deprecated in MonologBundle since version 3.11.0, use the "mongodb" type instead.');
+        // $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "mongo" handler type is deprecated in MonologBundle since version 3.11.0, use the "mongodb" type instead.');
 
         $container = new ContainerBuilder();
         $container->setDefinition('mongodb.client', new Definition('MongoDB\Client'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, we have a mix of strings and constants. I suggest using constants everywhere. This actually helped me spot #553.

I targeted 4.x because there would be a lot of conflicts if done on 3.x.

Also, I intentionally didn't import non-Symfony classes, as I think this is more readable. That's just my opinion though, I'm fine with imports as well.