### PR TITLE
Remove "mongo" handler type

### DIFF
--- a/CHANGELOG-4.md
+++ b/CHANGELOG-4.md
@@ -10,6 +10,7 @@
 * Remove `excluded_404s` option, use `excluded_http_codes` instead
 * Remove `console_formater_options` option, use `console_formatter_options` instead
 * Remove `elasticsearch` type, use `elastica` or `elastic_search` instead
+* Remove `mongo` type, use `mongodb` instead
 * Remove `sentry` and `raven` types, use a `service` type with [`sentry/sentry-symfony`](https://docs.sentryio/platforms/php/guides/symfony/logs/) instead
 * Remove `DebugHandlerPass`
 * Remove support for the `DebugHandler`

--- a/config/schema/monolog-1.0.xsd
+++ b/config/schema/monolog-1.0.xsd
@@ -20,7 +20,6 @@
             <xsd:element name="member" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="channels" type="channels" minOccurs="0" maxOccurs="1" />
             <xsd:element name="publisher" type="publisher" minOccurs="0" maxOccurs="1" />
-            <xsd:element name="mongo" type="mongo" minOccurs="0" maxOccurs="1" />
             <xsd:element name="mongodb" type="mongodb" minOccurs="0" maxOccurs="1" />
             <xsd:element name="elasticsearch" type="elasticsearch" minOccurs="0" maxOccurs="1" />
             <xsd:element name="config" type="xsd:anyType" minOccurs="0" maxOccurs="1" />
@@ -147,16 +146,6 @@
             <xsd:enumeration value="exclusive" />
         </xsd:restriction>
     </xsd:simpleType>
-
-    <xsd:complexType name="mongo">
-        <xsd:attribute name="id" type="xsd:string" />
-        <xsd:attribute name="host" type="xsd:string" />
-        <xsd:attribute name="port" type="xsd:integer" />
-        <xsd:attribute name="user" type="xsd:string" />
-        <xsd:attribute name="pass" type="xsd:string" />
-        <xsd:attribute name="database" type="xsd:string" />
-        <xsd:attribute name="collection" type="xsd:string" />
-    </xsd:complexType>
 
     <xsd:complexType name="mongodb">
         <xsd:attribute name="id" type="xsd:string" />

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -79,18 +79,6 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [filename_format]: string, defaults to '{filename}-{date}'
  *   - [date_format]: string, defaults to 'Y-m-d'
  *
- * - mongo:
- *   - mongo:
- *      - id: optional if host is given
- *      - host: database host name, optional if id is given
- *      - [port]: defaults to 27017
- *      - [user]: database user name
- *      - pass: mandatory only if user is present
- *      - [database]: defaults to monolog
- *      - [collection]: defaults to logs
- *   - [level]: level name or int value, defaults to DEBUG
- *   - [bubble]: bool, defaults to true
- *
  * - mongodb:
  *    - mongodb:
  *       - id: optional if uri is given
@@ -584,7 +572,6 @@ final class Configuration implements ConfigurationInterface
             ->end();
 
         $this->addGelfSection($handlerNode);
-        $this->addMongoSection($handlerNode);
         $this->addMongoDBSection($handlerNode);
         $this->addElasticsearchSection($handlerNode);
         $this->addRedisSection($handlerNode);
@@ -738,46 +725,6 @@ final class Configuration implements ConfigurationInterface
             ->validate()
                 ->ifTrue(function ($v) { return 'gelf' === $v['type'] && !isset($v['publisher']); })
                 ->thenInvalid('The publisher has to be specified to use a GelfHandler')
-            ->end()
-        ;
-    }
-
-    private function addMongoSection(ArrayNodeDefinition $handlerNode): void
-    {
-        $handlerNode
-            ->children()
-                ->arrayNode('mongo')
-                    ->canBeUnset()
-                    ->beforeNormalization()
-                    ->ifString()
-                    ->then(function ($v) { return ['id' => $v]; })
-                    ->end()
-                    ->children()
-                        ->scalarNode('id')->end()
-                        ->scalarNode('host')->end()
-                        ->scalarNode('port')->defaultValue(27017)->end()
-                        ->scalarNode('user')->end()
-                        ->scalarNode('pass')->end()
-                        ->scalarNode('database')->defaultValue('monolog')->end()
-                        ->scalarNode('collection')->defaultValue('logs')->end()
-                    ->end()
-                    ->validate()
-                    ->ifTrue(function ($v) {
-                        return !isset($v['id']) && !isset($v['host']);
-                    })
-                    ->thenInvalid('The "mongo" handler configuration requires either a service "id" or a connection "host".')
-                    ->end()
-                    ->validate()
-                    ->ifTrue(function ($v) {
-                        return isset($v['user']) && !isset($v['pass']);
-                    })
-                    ->thenInvalid('If you set user, you must provide a password.')
-                    ->end()
-                ->end()
-            ->end()
-            ->validate()
-                ->ifTrue(function ($v) { return 'mongo' === $v['type'] && !isset($v['mongo']); })
-                ->thenInvalid('The "mongo" configuration has to be specified to use a "mongo" handler type.')
             ->end()
         ;
     }

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -231,39 +231,6 @@ final class MonologExtension extends Extension
                 ]);
                 break;
 
-            case 'mongo':
-                trigger_deprecation('symfony/monolog-bundle', '3.11', 'The "mongo" handler type is deprecated in MonologBundle since version 3.11.0, use the "mongodb" type instead.');
-
-                if (!class_exists(\MongoDB\Client::class)) {
-                    throw new \RuntimeException('The "mongo" handler requires the mongodb/mongodb package to be installed.');
-                }
-
-                if (isset($handler['mongo']['id'])) {
-                    $client = new Reference($handler['mongo']['id']);
-                } else {
-                    $server = 'mongodb://';
-
-                    if (isset($handler['mongo']['user'])) {
-                        $server .= $handler['mongo']['user'].':'.$handler['mongo']['pass'].'@';
-                    }
-
-                    $server .= $handler['mongo']['host'].':'.$handler['mongo']['port'];
-
-                    $client = new Definition(\MongoDB\Client::class, [
-                        $server,
-                        ['appname' => 'monolog-bundle'],
-                    ]);
-                }
-
-                $definition->setArguments([
-                    $client,
-                    $handler['mongo']['database'],
-                    $handler['mongo']['collection'],
-                    $handler['level'],
-                    $handler['bubble'],
-                ]);
-                break;
-
             case 'mongodb':
                 if (!class_exists(\MongoDB\Client::class)) {
                     throw new \RuntimeException('The "mongodb" handler requires the mongodb/mongodb package to be installed.');
@@ -301,10 +268,6 @@ final class MonologExtension extends Extension
                     $definition->addMethodCall('setFormatter', [$formatter]);
                 }
                 break;
-
-            case 'elasticsearch':
-                trigger_deprecation('symfony/monolog-bundle', '3.8', 'The "elasticsearch" handler type is deprecated in MonologBundle since version 3.8.0, use the "elastica" type instead, or switch to the official Elastic client using the "elastic_search" type.');
-                // no break
 
             case 'elastica':
             case 'elastic_search':
@@ -859,7 +822,7 @@ final class MonologExtension extends Extension
             'whatfailuregroup' => \Monolog\Handler\WhatFailureGroupHandler::class,
             'fingers_crossed' => \Monolog\Handler\FingersCrossedHandler::class,
             'filter' => \Monolog\Handler\FilterHandler::class,
-            'mongo','mongodb' => \Monolog\Handler\MongoDBHandler::class,
+            'mongodb' => \Monolog\Handler\MongoDBHandler::class,
             'telegram' => \Monolog\Handler\TelegramBotHandler::class,
             'server_log' => \Symfony\Bridge\Monolog\Handler\ServerLogHandler::class,
             'redis', 'predis' => \Monolog\Handler\RedisHandler::class,

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -18,8 +18,6 @@ use Monolog\Handler\MongoDBHandler;
 use Monolog\Handler\RollbarHandler;
 use Monolog\Processor\UidProcessor;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessorWithPriority;
@@ -554,84 +552,6 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertInstanceOf(Definition::class, $elasticaClient);
         $this->assertSame(\Elastica\Client::class, $elasticaClient->getClass());
         $this->assertSame(['hosts' => ['es:9200'], 'transport' => 'Http'], $elasticaClient->getArgument(0));
-    }
-
-    #[Group('legacy')]
-    #[IgnoreDeprecations]
-    public function testMongo()
-    {
-        if (!class_exists('MongoDB\Client')) {
-            $this->markTestSkipped('mongodb/mongodb is not installed.');
-        }
-
-        // $this->expectDeprecation('Since symfony/monolog-bundle 3.11: The "mongo" handler type is deprecated in MonologBundle since version 3.11.0, use the "mongodb" type instead.');
-
-        $container = new ContainerBuilder();
-        $container->setDefinition('mongodb.client', new Definition('MongoDB\Client'));
-
-        $config = [[
-            'handlers' => [
-                'mongo_with_id' => [
-                    'type' => 'mongo',
-                    'mongo' => ['id' => 'mongodb.client'],
-                ],
-                'mongo_with_string_id' => [
-                    'type' => 'mongo',
-                    'mongo' => 'mongodb.client',
-                ],
-                'mongo_with_host' => [
-                    'type' => 'mongo',
-                    'mongo' => [
-                        'host' => 'localhost',
-                        'port' => '27018',
-                        'user' => 'username',
-                        'pass' => 'password',
-                        'database' => 'db',
-                        'collection' => 'coll',
-                    ],
-                ],
-                'mongo_with_host_and_default_args' => [
-                    'type' => 'mongo',
-                    'mongo' => [
-                        'host' => 'localhost',
-                    ],
-                ],
-            ],
-        ]];
-
-        $extension = new MonologExtension();
-        $extension->load($config, $container);
-
-        $this->assertTrue($container->hasDefinition('monolog.handler.mongo_with_id'));
-        $this->assertTrue($container->hasDefinition('monolog.handler.mongo_with_string_id'));
-        $this->assertTrue($container->hasDefinition('monolog.handler.mongo_with_host'));
-        $this->assertTrue($container->hasDefinition('monolog.handler.mongo_with_host_and_default_args'));
-
-        // MongoDB handler should receive the mongodb.client as first argument
-        $handler = $container->getDefinition('monolog.handler.mongo_with_id');
-        $this->assertDICDefinitionClass($handler, MongoDBHandler::class);
-        $this->assertDICConstructorArguments($handler, [new Reference('mongodb.client'), 'monolog', 'logs', 'DEBUG', true]);
-
-        // MongoDB handler should receive the mongodb.client as first argument
-        $handler = $container->getDefinition('monolog.handler.mongo_with_string_id');
-        $this->assertDICDefinitionClass($handler, MongoDBHandler::class);
-        $this->assertDICConstructorArguments($handler, [new Reference('mongodb.client'), 'monolog', 'logs', 'DEBUG', true]);
-
-        // MongoDB handler with host and arguments
-        $handler = $container->getDefinition('monolog.handler.mongo_with_host');
-        $this->assertDICDefinitionClass($handler, MongoDBHandler::class);
-        $client = $handler->getArgument(0);
-        $this->assertDICDefinitionClass($client, 'MongoDB\Client');
-        $this->assertDICConstructorArguments($client, ['mongodb://username:password@localhost:27018', ['appname' => 'monolog-bundle']]);
-        $this->assertDICConstructorArguments($handler, [$client, 'db', 'coll', 'DEBUG', true]);
-
-        // MongoDB handler with host and default arguments
-        $handler = $container->getDefinition('monolog.handler.mongo_with_host_and_default_args');
-        $this->assertDICDefinitionClass($handler, MongoDBHandler::class);
-        $client = $handler->getArgument(0);
-        $this->assertDICDefinitionClass($client, 'MongoDB\Client');
-        $this->assertDICConstructorArguments($client, ['mongodb://localhost:27017', ['appname' => 'monolog-bundle']]);
-        $this->assertDICConstructorArguments($handler, [$client, 'monolog', 'logs', 'DEBUG', true]);
     }
 
     public function testMongoDB()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | After https://github.com/symfony/monolog-bundle/pull/550
| License       | MIT

The `mongo` handler type is replaced by `mongodb`.