### PR TITLE
Allow unset of `excluded_http_codes`

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -518,9 +518,15 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('excluded_http_codes') // fingers_crossed
+                    ->info('Only for "fingers_crossed" handler type')
+                    ->example([403, 404, [400 => ['^/foo', '^/bar']]])
                     ->canBeUnset()
                     ->beforeNormalization()
                         ->always(function ($values) {
+                            if (false === $values) {
+                                return false;
+                            }
+
                             return array_map(function ($value) {
                                 /*
                                  * Allows YAML:

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -74,6 +74,43 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expectedString, $config['handlers']['foobar']['channels']['elements'][0]);
     }
 
+    public function testUnsetExcludedHttpCodes()
+    {
+        $configs = [
+            [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'fingers_crossed',
+                        'action_level' => 'error',
+                        'handler' => 'nested',
+                        'excluded_http_codes' => [404, 405],
+                        'channels' => ['!event'],
+                    ],
+                    'nested' => [
+                        'type' => 'stream',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                        'level' => 'debug',
+                    ],
+                ],
+            ],
+            [
+                'handlers' => [
+                    'main' => [
+                        'type' => 'stream',
+                        'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                        'level' => 'debug',
+                        'excluded_http_codes' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $config = $this->process($configs);
+
+        $this->assertArrayNotHasKey('excluded_http_codes', $config['handlers']['main']);
+        $this->assertIsArray($config['handlers']['main']['channels']);
+    }
+
     public static function provideGelfPublisher(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | yes/no
| Deprecations? | yes/no
| Issues        | Fix #502
| License       | MIT

Removing the `excluded_http_codes` is allowed by `canBeUnset()`
https://github.com/symfony/monolog-bundle/blob/ec54eb1624ae76056ddbeaa68e7db4bfe7ce774b/src/DependencyInjection/Configuration.php#L520-L521

There was an issue with the transformation of the array, as `array_map` is called with `false`.