### PR TITLE
Fix `rollbar` handler to use `RollbarLogger` with Monolog 2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## unreleased
+
+* Fix `rollbar` handler to use `RollbarLogger` with Monolog 2+
+
 ## 3.11.0 (2025-11-27)
 
 * Reorganize files to match the "Reusable Bundles" structure

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -930,10 +930,10 @@ class MonologExtension extends Extension
                 } else {
                     $config = $handler['config'] ?: [];
                     $config['access_token'] = $handler['token'];
-                    $rollbar = new Definition('RollbarNotifier', [
+                    $rollbar = new Definition('Rollbar\RollbarLogger', [
                         $config,
                     ]);
-                    $rollbarId = 'monolog.rollbar.notifier.'.sha1(json_encode($config));
+                    $rollbarId = 'monolog.rollbar.logger.'.sha1(json_encode($config));
                     $rollbar->setPublic(false);
                     $container->setDefinition($rollbarId, $rollbar);
                 }

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -930,10 +930,10 @@ class MonologExtension extends Extension
                 } else {
                     $config = $handler['config'] ?: [];
                     $config['access_token'] = $handler['token'];
-                    $rollbar = new Definition('Rollbar\RollbarLogger', [
+                    $rollbar = new Definition(Logger::API === 1 ? 'RollbarNotifier' : 'Rollbar\RollbarLogger', [
                         $config,
                     ]);
-                    $rollbarId = 'monolog.rollbar.logger.'.sha1(json_encode($config));
+                    $rollbarId = 'monolog.rollbar.notifier.'.sha1(json_encode($config));
                     $rollbar->setPublic(false);
                     $container->setDefinition($rollbarId, $rollbar);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x <!-- for features and bug -->
| Bug fix?      | yes
| New feature?  | o
| Deprecations? | no
| License       | MIT

Improves the compatibility with the latest Rollbar library. Rollbar has renamed their classes a while ago.