### PR TITLE
Fix tags list to use consecutive keys

### DIFF
--- a/src/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/src/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -39,7 +39,7 @@ class AddProcessorsPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('monolog.processor') as $id => $tags) {
             if (array_any($tags, $closure = function (array $tag) { return (bool) $tag; })) {
-                $tags = array_filter($tags, $closure);
+                $tags = array_values(array_filter($tags, $closure));
             }
 
             foreach ($tags as &$tag) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Workaround a bug introduced in https://github.com/symfony/symfony/pull/62329
The Symfony code incorrectly assumes that the tags array is a list. But we use `array_filter` which leaves gaps in the array keys. Fixed here by using `array_values` to reset the keys.

Fix [failing job](https://github.com/symfony/monolog-bundle/actions/runs/19731209625/job/56532483316):

```
There were 3 errors:

1) Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\AddProcessorsPassTest::testEmptyTagsAreIgnoredWhenNonEmptyArePresent with data set "with app channel" (array(array(), array('app')), array(array('useMicrosecondTimestamps', array('%monolog.use_microseconds%')), array('pushProcessor', array(Symfony\Component\DependencyInjection\Reference Object (...)))), array())
Undefined array key 0

/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/Compiler/PriorityTaggedServiceTrait.php:86
/home/runner/work/monolog-bundle/monolog-bundle/src/DependencyInjection/Compiler/AddProcessorsPass.php:55
/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/ContainerBuilder.php:820
/home/runner/work/monolog-bundle/monolog-bundle/tests/DependencyInjection/Compiler/AddProcessorsPassTest.php:119

2) Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\AddProcessorsPassTest::testEmptyTagsAreIgnoredWhenNonEmptyArePresent with data set "with my_channel channel" (array(array(), array('my_channel')), array(array('useMicrosecondTimestamps', array('%monolog.use_microseconds%'))), array(array('pushProcessor', array(Symfony\Component\DependencyInjection\Reference Object (...)))))
Undefined array key 0

/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/Compiler/PriorityTaggedServiceTrait.php:86
/home/runner/work/monolog-bundle/monolog-bundle/src/DependencyInjection/Compiler/AddProcessorsPass.php:55
/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/ContainerBuilder.php:820
/home/runner/work/monolog-bundle/monolog-bundle/tests/DependencyInjection/Compiler/AddProcessorsPassTest.php:119

3) Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\AddProcessorsPassTest::testEmptyTagsAreIgnoredWhenNonEmptyArePresent with data set "with method and no channel" (array(array(), array('foo')), array(array('useMicrosecondTimestamps', array('%monolog.use_microseconds%')), array('pushProcessor', array(array(Symfony\Component\DependencyInjection\Reference Object (...), 'foo')))), array(array('pushProcessor', array(array(Symfony\Component\DependencyInjection\Reference Object (...), 'foo')))))
Undefined array key 0

/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/Compiler/PriorityTaggedServiceTrait.php:86
/home/runner/work/monolog-bundle/monolog-bundle/src/DependencyInjection/Compiler/AddProcessorsPass.php:55
/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/Compiler/Compiler.php:73
/home/runner/work/monolog-bundle/monolog-bundle/vendor/symfony/dependency-injection/ContainerBuilder.php:820
/home/runner/work/monolog-bundle/monolog-bundle/tests/DependencyInjection/Compiler/AddProcessorsPassTest.php:119
```