### PR TITLE
Import Extension from the DependencyInjection component rather than HttpKernel

### DIFF
--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -26,9 +26,9 @@ use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Extension class from the HttpKernel component is marked as internal since Symfony 7.1 and is going to be deprecated in 8.1 (see https://github.com/symfony/symfony/pull/62434). 

I can target 3.x if preferred.
