### PR TITLE
Fix TaggedIteratorArgument deprecation warning when using symfony/dependency-injection 8.1

### DIFF
--- a/src/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/src/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -50,7 +50,7 @@ class AddProcessorsPass implements CompilerPassInterface
             $definition->setTags(array_merge($definition->getTags(), ['monolog.processor' => $tags]));
         }
 
-        $taggedIteratorArgument = new TaggedIteratorArgument('monolog.processor', 'index', null, true);
+        $taggedIteratorArgument = new TaggedIteratorArgument('monolog.processor', 'index', needsIndexes: true);
         // array_reverse is used because ProcessableHandlerTrait::pushProcessor prepends processors to the beginning of the stack
         foreach (array_reverse($this->findAndSortTaggedServices($taggedIteratorArgument, $container), true) as $index => $reference) {
             $tag = $indexedTags[$index];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? |no
| Issues        | -
| License       | MIT

Seen in action log of https://github.com/symfony/monolog-bundle/pull/569:  https://github.com/symfony/monolog-bundle/actions/runs/21171362032/job/60888672245?pr=569

Ref: https://github.com/symfony/symfony/pull/62339