### PR TITLE
Add missing target to named autowiring alias

### DIFF
--- a/src/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/src/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -143,7 +143,7 @@ class LoggerChannelPass implements CompilerPassInterface
             $this->channels[] = $channel;
         }
 
-        $container->registerAliasForArgument($loggerId, LoggerInterface::class, $channel.'.logger');
+        $container->registerAliasForArgument($loggerId, LoggerInterface::class, $channel.'.logger', $channel);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Makes `#[Target('channel')]` work instead of (in addition to actually) `#[Target('channel.logger')]`.