### PR TITLE
Add PHP 8.5 to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.2', '8.3', '8.4' ]
+                php: [ '8.2', '8.3', '8.4', '8.5' ]
                 symfony: [ false ]
                 deps: [ locked ]
                 extensions: [ '' ]
@@ -19,13 +19,13 @@ jobs:
                     -   php: '8.2'
                         deps: lowest
                         deprecations: max[self]=0
-                    -   php: '8.4'
+                    -   php: '8.5'
                         symfony: '7.4.*'
                         deps: highest
-                    -   php: '8.4'
+                    -   php: '8.5'
                         deps: highest
                         monolog: '3.*'
-                    -   php: '8.4'
+                    -   php: '8.5'
                         deps: locked
                         extensions: mongodb
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


please adjust to your needs.

i am not sure if this should be changed to symfony 8
`symfony: '7.4.*'`

Maybe there are more changes neccesary.