### PR TITLE
Add PHP 8.5 to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.1', '8.2', '8.3', '8.4' ]
+                php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 monolog: [ '2.*' ]
                 symfony: [ false ]
                 extensions: [ '' ]
@@ -24,10 +24,10 @@ jobs:
                     -   php: '8.1'
                         monolog: '3.*'
                         symfony: '6.4.*'
-                    -   php: '8.4'
+                    -   php: '8.5'
                         deps: highest
                         monolog: '3.*'
-                    -   php: '8.4'
+                    -   php: '8.5'
                         extensions: mongodb
 
         env:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Add PHP 8.5 to the CI matrix. This is the same as https://github.com/symfony/monolog-bundle/pull/575 applied to the 3.x branch.