### PR TITLE
Add `base_path` option for `LineFormatter`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.2",
         "composer-runtime-api": "^2.0",
-        "monolog/monolog": "^3.5",
+        "monolog/monolog": "^3.6",
         "symfony/config": "^7.3 || ^8.0",
         "symfony/dependency-injection": "^7.3 || ^8.0",
         "symfony/http-kernel": "^7.3 || ^8.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *   - [file_permission]: int|null, defaults to null (0644)
  *   - [use_locking]: bool, defaults to false
+ *   - [base_path]: string|null, base path to strip from file paths in stack traces (e.g. %kernel.project_dir%)
  *
  * - console:
  *   - [verbosity_levels]: level => verbosity configuration
@@ -416,6 +417,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('interactive_only')->defaultFalse()->end()
                 ->scalarNode('app_name')->defaultNull()->end()
                 ->booleanNode('include_stacktraces')->defaultFalse()->end()
+                ->scalarNode('base_path')->defaultNull()->end()
                 ->arrayNode('process_psr_3_messages')
                     ->addDefaultsIfNotSet()
                     ->beforeNormalization()

--- a/src/DependencyInjection/FormatterConfigurator.php
+++ b/src/DependencyInjection/FormatterConfigurator.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\DependencyInjection;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\HandlerInterface;
+
+/**
+ * Configures formatter options on handlers.
+ *
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ *
+ * @internal
+ */
+final class FormatterConfigurator
+{
+    public function __construct(
+        private bool $includeStacktraces = false,
+        private ?string $basePath = null,
+    ) {
+    }
+
+    public function __invoke(HandlerInterface $handler): void
+    {
+        $formatter = $handler->getFormatter();
+
+        if ($this->includeStacktraces && ($formatter instanceof LineFormatter || $formatter instanceof JsonFormatter)) {
+            $formatter->includeStacktraces();
+        }
+
+        if (null !== $this->basePath && $formatter instanceof LineFormatter) {
+            $formatter->setBasePath($this->basePath);
+        }
+    }
+}

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -20,7 +20,6 @@ use Monolog\Processor\PsrLogMessageProcessor;
 use Monolog\ResettableInterface;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
-use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -147,8 +146,12 @@ final class MonologExtension extends Extension
         $handlerClass = $this->getHandlerClassByType($handler['type']);
         $definition = new Definition($handlerClass);
 
-        if ($handler['include_stacktraces']) {
-            $definition->setConfigurator([MonologBundle::class, 'includeStacktraces']);
+        if ($handler['include_stacktraces'] || null !== $handler['base_path']) {
+            $configurator = new Definition(FormatterConfigurator::class, [
+                $handler['include_stacktraces'],
+                $handler['base_path'],
+            ]);
+            $definition->setConfigurator([$configurator, '__invoke']);
         }
 
         if (null === $handler['process_psr_3_messages']['enabled']) {

--- a/src/MonologBundle.php
+++ b/src/MonologBundle.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Bundle\MonologBundle;
 
-use Monolog\Formatter\JsonFormatter;
-use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\HandlerInterface;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddProcessorsPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,16 +27,5 @@ final class MonologBundle extends Bundle
 
         $container->addCompilerPass(new LoggerChannelPass());
         $container->addCompilerPass(new AddProcessorsPass());
-    }
-
-    /**
-     * @internal
-     */
-    public static function includeStacktraces(HandlerInterface $handler): void
-    {
-        $formatter = $handler->getFormatter();
-        if ($formatter instanceof LineFormatter || $formatter instanceof JsonFormatter) {
-            $formatter->includeStacktraces();
-        }
     }
 }

--- a/tests/DependencyInjection/FormatterConfiguratorTest.php
+++ b/tests/DependencyInjection/FormatterConfiguratorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MonologBundle\DependencyInjection\FormatterConfigurator;
+
+class FormatterConfiguratorTest extends TestCase
+{
+    public function testIncludeStacktracesOnLineFormatter()
+    {
+        $handler = new StreamHandler('php://memory');
+        $formatter = new LineFormatter();
+        $handler->setFormatter($formatter);
+
+        $configurator = new FormatterConfigurator(includeStacktraces: true);
+        $configurator($handler);
+
+        // Verify includeStacktraces was called by formatting a record with an exception
+        $exception = new \Exception('Test exception');
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: \Monolog\Level::Error,
+            message: 'Test',
+            context: ['exception' => $exception],
+        );
+        $output = $handler->getFormatter()->format($record);
+        $this->assertStringContainsString('[stacktrace]', $output);
+    }
+
+    public function testIncludeStacktracesOnJsonFormatter()
+    {
+        $handler = new StreamHandler('php://memory');
+        $formatter = new JsonFormatter();
+        $handler->setFormatter($formatter);
+
+        $configurator = new FormatterConfigurator(includeStacktraces: true);
+        $configurator($handler);
+
+        // Verify includeStacktraces was called by formatting a record with an exception
+        $exception = new \Exception('Test exception');
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: \Monolog\Level::Error,
+            message: 'Test',
+            context: ['exception' => $exception],
+        );
+        $output = $handler->getFormatter()->format($record);
+        $this->assertStringContainsString('"trace":', $output);
+    }
+
+    public function testBasePathOnLineFormatter()
+    {
+        $handler = new StreamHandler('php://memory');
+        $formatter = new LineFormatter();
+        $handler->setFormatter($formatter);
+
+        $configurator = new FormatterConfigurator(includeStacktraces: true, basePath: '/var/www/project');
+        $configurator($handler);
+
+        // Verify basePath was applied by formatting a record with an exception
+        // The base path should be stripped from stack trace paths
+        $exception = new \Exception('Test exception');
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: \Monolog\Level::Error,
+            message: 'Test',
+            context: ['exception' => $exception],
+        );
+        $output = $handler->getFormatter()->format($record);
+        // Just verify the formatter works after basePath was set
+        $this->assertStringContainsString('[stacktrace]', $output);
+    }
+
+    public function testBasePathAndIncludeStacktraces()
+    {
+        $handler = new StreamHandler('php://memory');
+        $formatter = new LineFormatter();
+        $handler->setFormatter($formatter);
+
+        $configurator = new FormatterConfigurator(includeStacktraces: true, basePath: '/var/www/project');
+        $configurator($handler);
+
+        $this->assertInstanceOf(LineFormatter::class, $handler->getFormatter());
+    }
+
+    public function testBasePathIgnoredOnJsonFormatter()
+    {
+        $handler = new StreamHandler('php://memory');
+        $formatter = new JsonFormatter();
+        $handler->setFormatter($formatter);
+
+        // base_path only applies to LineFormatter, should not throw
+        $configurator = new FormatterConfigurator(basePath: '/var/www/project');
+        $configurator($handler);
+
+        $this->assertInstanceOf(JsonFormatter::class, $handler->getFormatter());
+    }
+
+    public function testNoConfigurationApplied()
+    {
+        $handler = new StreamHandler('php://memory');
+        $formatter = new LineFormatter();
+        $handler->setFormatter($formatter);
+
+        $configurator = new FormatterConfigurator();
+        $configurator($handler);
+
+        $this->assertInstanceOf(LineFormatter::class, $handler->getFormatter());
+    }
+}

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -19,6 +19,7 @@ use Monolog\Handler\RollbarHandler;
 use Monolog\Processor\UidProcessor;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
+use Symfony\Bundle\MonologBundle\DependencyInjection\FormatterConfigurator;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessorWithPriority;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\RedeclareMethodProcessor;
@@ -632,6 +633,69 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($client, ['mongodb://localhost:27018', ['appname' => 'monolog-bundle']]);
         $this->assertDICConstructorArguments($handler, [$client, 'monolog', 'logs', 'DEBUG', true]);
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setFormatter', [$formatter]);
+    }
+
+    public function testBasePathOption()
+    {
+        $container = $this->getContainer([['handlers' => [
+            'main' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'base_path' => '/var/www/project',
+            ],
+        ]]]);
+
+        $this->assertTrue($container->hasDefinition('monolog.handler.main'));
+
+        $handler = $container->getDefinition('monolog.handler.main');
+        $configuratorRef = $handler->getConfigurator();
+        $this->assertIsArray($configuratorRef);
+        [$configurator, $method] = $configuratorRef;
+        $this->assertInstanceOf(Definition::class, $configurator);
+        $this->assertSame('__invoke', $method);
+        $this->assertDICDefinitionClass($configurator, FormatterConfigurator::class);
+        $this->assertDICConstructorArguments($configurator, [false, '/var/www/project']);
+    }
+
+    public function testBasePathWithIncludeStacktraces()
+    {
+        $container = $this->getContainer([['handlers' => [
+            'main' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'base_path' => '/var/www/project',
+                'include_stacktraces' => true,
+            ],
+        ]]]);
+
+        $handler = $container->getDefinition('monolog.handler.main');
+        $configuratorRef = $handler->getConfigurator();
+        $this->assertIsArray($configuratorRef);
+        [$configurator, $method] = $configuratorRef;
+        $this->assertInstanceOf(Definition::class, $configurator);
+        $this->assertSame('__invoke', $method);
+        $this->assertDICDefinitionClass($configurator, FormatterConfigurator::class);
+        $this->assertDICConstructorArguments($configurator, [true, '/var/www/project']);
+    }
+
+    public function testIncludeStacktracesWithFormatterConfigurator()
+    {
+        $container = $this->getContainer([['handlers' => [
+            'main' => [
+                'type' => 'stream',
+                'path' => '/tmp/symfony.log',
+                'include_stacktraces' => true,
+            ],
+        ]]]);
+
+        $handler = $container->getDefinition('monolog.handler.main');
+        $configuratorRef = $handler->getConfigurator();
+        $this->assertIsArray($configuratorRef);
+        [$configurator, $method] = $configuratorRef;
+        $this->assertInstanceOf(Definition::class, $configurator);
+        $this->assertSame('__invoke', $method);
+        $this->assertDICDefinitionClass($configurator, FormatterConfigurator::class);
+        $this->assertDICConstructorArguments($configurator, [true, null]);
     }
 
     private function getContainer(array $config = [], array $thirdPartyDefinitions = []): ContainerBuilder


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #478
| License       | MIT

This adds the `base_path` configuration option for handlers, allowing to strip a base path from stack traces. Uses Monolog 3.6.0's `LineFormatter::setBasePath()`.

The existing `MonologBundle::includeStacktraces()` method is replaced by a `FormatterConfigurator` service that handles both options.