### PR TITLE
Add Google Cloud formatter to default services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `GoogleCloudLoggingFormatter` as `monolog.formatter.google` to services
+
 ## 4.0.2 (2026-04-02)
 
 * Fix `TaggedIteratorArgument` deprecation warning when using `symfony/dependency-injection` 8.1

--- a/config/monolog.php
+++ b/config/monolog.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Monolog\Formatter\ChromePHPFormatter;
 use Monolog\Formatter\GelfMessageFormatter;
+use Monolog\Formatter\GoogleCloudLoggingFormatter;
 use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Formatter\LineFormatter;
@@ -46,6 +47,7 @@ return static function (ContainerConfigurator $container) {
         // Formatters
         ->set('monolog.formatter.chrome_php', ChromePHPFormatter::class)
         ->set('monolog.formatter.gelf_message', GelfMessageFormatter::class)
+        ->set('monolog.formatter.google', GoogleCloudLoggingFormatter::class)
         ->set('monolog.formatter.html', HtmlFormatter::class)
         ->set('monolog.formatter.json', JsonFormatter::class)
         ->set('monolog.formatter.line', LineFormatter::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's necessary
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- 📝 Add an entry to the changelog file
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
- ✨ New features and deprecations must target the **feature** branch
- 🔒 Do not break backward compatibility: https://symfony.com/bc
-->

Adds `GoogleCloudLoggingFormatter` to the default exposed services. The Google Cloud formatter is a class provided by monolog, so it makes sense to also expose it to the DI container so we can use it without having to add it to DI ourselves.

The Google Cloud formatter is pretty much essential for anyone running Symfony apps on Google Cloud infrastructure, otherwise the severity is unknown and the timestamp when the log is received is used instead of when the log was generated.

Before users had to manually register the `GoogleCloudLoggingFormatter`:
```php
    $services->set('app.logger.formatter.google', GoogleCloudLoggingFormatter::class);
```

And then use it in their monolog bundle config:
```
monolog:
    handlers:
        main:
            type: stream
            path: php://stderr
            level: info
            formatter: app.logger.formatter.google
```

After this change, users will no longer need to configure the `GoogleCloudLoggingFormatter` themselves and can just use `monolog.formatter.google` instead.