### PR TITLE
[ErrorLog] Add `expand_newlines` option to the `error_log` handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Add `GoogleCloudLoggingFormatter` as `monolog.formatter.google` to services
+* Add `expand_newlines` option to the `error_log` handler
 
 ## 4.0.2 (2026-04-02)
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -268,6 +268,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [message_type]: int 0 or 4, defaults to 0
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [expand_newlines]: bool, defaults to false
  *
  * - null:
  *   - [level]: level name or int value, defaults to DEBUG
@@ -550,6 +551,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('connection_timeout')->end() // socket_handler, logentries, pushover & slack
                 ->booleanNode('persistent')->end() // socket_handler
                 ->scalarNode('message_type')->defaultValue(0)->end() // error_log
+                ->booleanNode('expand_newlines')->defaultFalse()->end() // error_log
                 ->scalarNode('parse_mode')->defaultNull()->end() // telegram
                 ->booleanNode('disable_webpage_preview')->defaultNull()->end() // telegram
                 ->booleanNode('disable_notification')->defaultNull()->end() // telegram

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -634,6 +634,7 @@ final class MonologExtension extends Extension
                     $handler['message_type'],
                     $handler['level'],
                     $handler['bubble'],
+                    $handler['expand_newlines'],
                 ]);
                 break;
 


### PR DESCRIPTION
Per request in #580: exposes the `$expandNewlines` constructor argument of Monolog's `ErrorLogHandler` as a new `expand_newlines` boolean config option (defaults to `false`, preserving current behavior).

```yaml
monolog:
    handlers:
        main:
            type:            error_log
            message_type:    0
            expand_newlines: true
```

Fix #580