### PR TITLE
Skip disabled handlers when building group handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix `ServiceNotFoundException` when a disabled handler is a member of a `group`, `whatfailuregroup` or `fallbackgroup` handler
+
 ## 3.11.2 (2026-04-02)
 
 * Add missing target to named autowiring alias

--- a/src/DependencyInjection/MonologExtension.php
+++ b/src/DependencyInjection/MonologExtension.php
@@ -45,6 +45,8 @@ class MonologExtension extends Extension
 {
     private $nestedHandlers = [];
 
+    private $disabledHandlers = [];
+
     private $swiftMailerHandlers = [];
 
     /**
@@ -65,6 +67,14 @@ class MonologExtension extends Extension
             $container->setParameter('monolog.use_microseconds', $config['use_microseconds']);
 
             $handlers = [];
+
+            // Collect disabled handlers first so that group members referencing
+            // them can be skipped, regardless of the order they are declared in.
+            foreach ($config['handlers'] as $name => $handler) {
+                if (!$handler['enabled']) {
+                    $this->disabledHandlers[$name] = true;
+                }
+            }
 
             foreach ($config['handlers'] as $name => $handler) {
                 if (!$handler['enabled']) {
@@ -558,6 +568,10 @@ class MonologExtension extends Extension
             case 'fallbackgroup':
                 $references = [];
                 foreach ($handler['members'] as $nestedHandler) {
+                    if (isset($this->disabledHandlers[$nestedHandler])) {
+                        // a disabled handler is not registered as a service, skip it
+                        continue;
+                    }
                     $nestedHandlerId = $this->getHandlerId($nestedHandler);
                     $this->markNestedHandler($nestedHandlerId);
                     $references[] = new Reference($nestedHandlerId);

--- a/tests/DependencyInjection/MonologExtensionTest.php
+++ b/tests/DependencyInjection/MonologExtensionTest.php
@@ -92,6 +92,26 @@ class MonologExtensionTest extends DependencyInjectionTestCase
         $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, false]);
     }
 
+    public function testLoadWithGroupHandlerAndDisabledMember()
+    {
+        $container = $this->getContainer([['handlers' => [
+            'main' => ['type' => 'group', 'members' => ['enabled_member', 'disabled_member']],
+            'enabled_member' => ['type' => 'stream', 'path' => '/tmp/symfony.log'],
+            'disabled_member' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'enabled' => false],
+        ]]]);
+
+        $this->assertTrue($container->hasDefinition('monolog.handler.main'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.enabled_member'));
+        // a disabled handler is not registered as a service...
+        $this->assertFalse($container->hasDefinition('monolog.handler.disabled_member'));
+
+        // ...and is therefore skipped from the group it belongs to, instead of
+        // leaving a reference to a non-existent service (see issue #561)
+        $handler = $container->getDefinition('monolog.handler.main');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\GroupHandler');
+        $this->assertDICConstructorArguments($handler, [[new Reference('monolog.handler.enabled_member')], true]);
+    }
+
     public function testLoadWithServiceHandler()
     {
         $container = $this->getContainer(


### PR DESCRIPTION
Fixes #561

When a handler is declared with `enabled: false`, its service is never registered. But if that handler is also listed as a **member of a `group` / `whatfailuregroup` / `fallbackgroup` handler**, the group still builds a `Reference` to the (now non-existent) service, leading to a container compile error:

```
The service "monolog.handler.grouped" has a dependency on a non-existent service "monolog.handler.streamed".
```

This collects the disabled handler names up-front (so members can be filtered regardless of declaration order) and skips disabled members when assembling group handlers — consistent with the "a disabled handler is absent" semantics already applied at the top level.

Scope is intentionally limited to the group handlers, where dropping a member is meaningful. Single-nested-handler wrappers (`fingers_crossed`, `buffer`, …) require their inner handler, so disabling it there is a different concern.

Added a unit test covering a `group` with one enabled and one disabled member.